### PR TITLE
fix(lib): :bug: fix Derive npm/npx paths from node path

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1593,7 +1593,8 @@ async fn detect_copilot_api(app: tauri::AppHandle) -> Result<CopilotApiDetection
             if n_trimmed == "node" {
                 "npx".to_string()
             } else if n_trimmed.ends_with("/node") {
-                format!("{}/npx", &n_trimmed[..n_trimmed.len() - 5])
+                let node_len = "/node".len();
+                format!("{}/npx", &n_trimmed[..n_trimmed.len() - node_len])
             } else {
                 // Fallback: npx should be alongside node
                 "npx".to_string()


### PR DESCRIPTION
<img width="764" height="284" alt="Screenshot 2025-12-07 at 13 10 22" src="https://github.com/user-attachments/assets/d6a154cd-6039-4b31-b16a-a3bc2fcf1f22" />

This pull request improves the logic for deriving the `npx` binary path from the `node` binary path in the `detect_copilot_api` function. The update adds more robust handling for both Windows and Unix systems, including special cases when the path is simply `"node"` or `"node.exe"`.

Enhancements to binary path detection:

* Improved Windows handling: If the `node_bin` value is `"node"` or `"node.exe"`, it now directly returns `"npx.cmd"` instead of using string replacement.
* Improved Unix handling: If the `node_bin` value is `"node"`, it returns `"npx"`. If the path ends with `"/node"`, it replaces it with `"/npx"` using string slicing. Otherwise, it falls back to `"npx"`.