### PR TITLE
feat(quota): enhance QuotaWidget with chart view and improved UX

### DIFF
--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -70,6 +70,14 @@ pub struct AppConfig {
     pub proxy_api_key: String,
     #[serde(default = "default_management_key")]
     pub management_key: String,
+    #[serde(default = "default_quota_view_mode")]
+    pub quota_view_mode: String,
+    #[serde(default)]
+    pub quota_selected_accounts: Vec<String>,
+    #[serde(default)]
+    pub quota_selected_models: Vec<String>,
+    #[serde(default = "default_quota_filters_expanded")]
+    pub quota_filters_expanded: bool,
 }
 
 fn default_management_key() -> String {
@@ -98,6 +106,14 @@ fn default_config_version() -> u8 {
 
 fn default_routing_strategy() -> String {
     "round-robin".to_string()
+}
+
+fn default_quota_view_mode() -> String {
+    "chart".to_string()
+}
+
+fn default_quota_filters_expanded() -> bool {
+    false
 }
 
 impl Default for AppConfig {
@@ -134,6 +150,10 @@ impl Default for AppConfig {
             max_retry_interval: 0,
             proxy_api_key: "proxypal-local".to_string(),
             management_key: "proxypal-mgmt-key".to_string(),
+            quota_view_mode: "chart".to_string(),
+            quota_selected_accounts: Vec::new(),
+            quota_selected_models: Vec::new(),
+            quota_filters_expanded: false,
         }
     }
 }

--- a/src/components/charts/BarChart.tsx
+++ b/src/components/charts/BarChart.tsx
@@ -1,11 +1,12 @@
 import type { EChartsOption } from "echarts";
-import { createMemo } from "solid-js";
+import { createMemo, type JSX } from "solid-js";
 import { EChartsWrapper } from "./EChartsWrapper";
 
 export interface BarChartData {
 	name: string;
 	value: number;
 	secondaryValue?: number;
+	resetTime?: string;
 }
 
 interface BarChartProps {
@@ -15,20 +16,79 @@ interface BarChartProps {
 	secondaryLabel?: string;
 	onClick?: (name: string) => void;
 	class?: string;
+	style?: JSX.CSSProperties;
 	horizontal?: boolean;
+	colorByValue?: boolean; // Enable quota-style color coding (green/yellow/red)
 }
 
 export function BarChart(props: BarChartProps) {
+	// Get quota-based color gradient
+	const getQuotaColor = (value: number) => {
+		if (value >= 70) {
+			return {
+				type: "linear" as const,
+				x: props.horizontal ? 0 : 0,
+				y: props.horizontal ? 0 : 1,
+				x2: props.horizontal ? 1 : 0,
+				y2: 0,
+				colorStops: [
+					{ offset: 0, color: "#10b981" }, // green-500
+					{ offset: 1, color: "#059669" }, // green-600
+				],
+			};
+		} else if (value >= 30) {
+			return {
+				type: "linear" as const,
+				x: props.horizontal ? 0 : 0,
+				y: props.horizontal ? 0 : 1,
+				x2: props.horizontal ? 1 : 0,
+				y2: 0,
+				colorStops: [
+					{ offset: 0, color: "#eab308" }, // yellow-500
+					{ offset: 1, color: "#ca8a04" }, // yellow-600
+				],
+			};
+		} else {
+			return {
+				type: "linear" as const,
+				x: props.horizontal ? 0 : 0,
+				y: props.horizontal ? 0 : 1,
+				x2: props.horizontal ? 1 : 0,
+				y2: 0,
+				colorStops: [
+					{ offset: 0, color: "#ef4444" }, // red-500
+					{ offset: 1, color: "#dc2626" }, // red-600
+				],
+			};
+		}
+	};
+
 	const option = createMemo((): EChartsOption => {
 		const isHorizontal = props.horizontal !== false;
-		const sortedData = [...props.data]
-			.sort((a, b) => b.value - a.value)
-			.slice(0, 7);
+		const sortedData = [...props.data].sort((a, b) => b.value - a.value);
+
+		// Prepare data with colors if colorByValue is enabled
+		const chartData = isHorizontal ? [...sortedData].reverse() : sortedData;
 
 		return {
 			tooltip: {
 				trigger: "axis",
 				axisPointer: { type: "shadow" },
+				appendToBody: true,
+				confine: true,
+					formatter: (params: Array<{ name?: string; value?: number; dataIndex?: number }>) => {
+					const p = params[0];
+					if (!p) return "";
+					const val = typeof p.value === "number" ? p.value.toFixed(1) : p.value;
+					const dataIndex = p.dataIndex ?? 0;
+					const item = chartData[dataIndex];
+					let result = `${p.name}: ${val}%`;
+					if (item?.resetTime) {
+						const resetDate = new Date(item.resetTime).toLocaleString();
+						result += `<br/>Resets: ${resetDate}`;
+					}
+					return result;
+				},
 			},
 			grid: {
 				left: isHorizontal ? 120 : 40,
@@ -71,24 +131,44 @@ export function BarChart(props: BarChartProps) {
 			series: [
 				{
 					type: "bar",
-					data: isHorizontal
-						? [...sortedData].reverse().map((d) => d.value)
-						: sortedData.map((d) => d.value),
+					data: props.colorByValue
+						? chartData.map((d) => ({
+								value: d.value,
+								itemStyle: {
+									color: getQuotaColor(d.value),
+								},
+							}))
+						: chartData.map((d) => d.value),
 					barWidth: "60%",
-					itemStyle: {
-						borderRadius: [4, 4, 4, 4],
-						color: {
-							type: "linear",
-							x: isHorizontal ? 0 : 0,
-							y: isHorizontal ? 0 : 1,
-							x2: isHorizontal ? 1 : 0,
-							y2: 0,
-							colorStops: [
-								{ offset: 0, color: "#3b82f6" }, // blue-500
-								{ offset: 1, color: "#2563eb" }, // blue-600
-							],
+					label: {
+						show: true,
+						position: "inside",
+						formatter: (params: { value?: number }) => {
+							const val = params.value ?? 0;
+							return `${val.toFixed(1)}%`;
 						},
+						fontSize: 11,
+						fontWeight: 500,
+						color: "#fff",
+						textShadowColor: "rgba(0,0,0,0.3)",
+						textShadowBlur: 2,
 					},
+					itemStyle: props.colorByValue
+						? { borderRadius: [4, 4, 4, 4] }
+						: {
+								borderRadius: [4, 4, 4, 4],
+								color: {
+									type: "linear",
+									x: isHorizontal ? 0 : 0,
+									y: isHorizontal ? 0 : 1,
+									x2: isHorizontal ? 1 : 0,
+									y2: 0,
+									colorStops: [
+										{ offset: 0, color: "#3b82f6" }, // blue-500
+										{ offset: 1, color: "#2563eb" }, // blue-600
+									],
+								},
+							},
 					emphasis: {
 						itemStyle: {
 							color: {
@@ -122,6 +202,7 @@ export function BarChart(props: BarChartProps) {
 		<EChartsWrapper
 			option={option()}
 			class={props.class}
+			style={props.style}
 			onChartClick={handleClick}
 		/>
 	);

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -285,6 +285,10 @@ export interface AppConfig {
 	forceModelMappings: boolean; // Force model mappings to take precedence over local API keys
 	proxyApiKey?: string; // API key for client authentication
 	managementKey?: string; // Management API key for internal proxy calls
+	quotaViewMode?: string;
+	quotaSelectedAccounts?: string[];
+	quotaSelectedModels?: string[];
+	quotaFiltersExpanded?: boolean;
 }
 
 export async function getConfig(): Promise<AppConfig> {

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,6 +1,7 @@
 import { open } from "@tauri-apps/plugin-dialog";
-import { createSignal, For, onCleanup, onMount, Show } from "solid-js";
+import { createEffect, createMemo, createSignal, For, onCleanup, onMount, Show } from "solid-js";
 import { ApiEndpoint } from "../components/ApiEndpoint";
+import { BarChart } from "../components/charts/BarChart";
 import { openCommandPalette } from "../components/CommandPalette";
 import { CopilotCard } from "../components/CopilotCard";
 import { HealthIndicator } from "../components/HealthIndicator";
@@ -24,6 +25,7 @@ import {
 	type Provider,
 	pollOAuthStatus,
 	refreshAuthStatus,
+	saveConfig,
 	startProxy,
 	stopProxy,
 	syncUsageFromProxy,
@@ -1015,7 +1017,7 @@ export function DashboardPage() {
 	);
 }
 
-// Antigravity Quota Widget - shows remaining quota for each model
+// Antigravity Quota Widget - shows remaining quota for each model with chart/list views
 function QuotaWidget(props: { authStatus: { antigravity: number } }) {
 	const [quotaData, setQuotaData] = createSignal<AntigravityQuotaResult[]>([]);
 	const [loading, setLoading] = createSignal(false);
@@ -1082,6 +1084,12 @@ function QuotaWidget(props: { authStatus: { antigravity: number } }) {
 		return quotas.filter((q) => !hiddenModels().has(q.model));
 	};
 
+	// View mode and filters from config
+	const [viewMode, setViewMode] = createSignal<"chart" | "list">("chart");
+	const [selectedAccounts, setSelectedAccounts] = createSignal<Set<string>>(new Set());
+	const [selectedModels, setSelectedModels] = createSignal<Set<string>>(new Set());
+	const [filtersExpanded, setFiltersExpanded] = createSignal(false);
+
 	const loadQuota = async () => {
 		setLoading(true);
 		setError(null);
@@ -1095,12 +1103,126 @@ function QuotaWidget(props: { authStatus: { antigravity: number } }) {
 		}
 	};
 
-	// Load quota when component mounts and antigravity is connected
+	// Load quota and config when component mounts
 	onMount(() => {
+		const cfg = appStore.config();
+		setViewMode((cfg.quotaViewMode as "chart" | "list") || "chart");
+		setSelectedAccounts(new Set(cfg.quotaSelectedAccounts || []));
+		setSelectedModels(new Set(cfg.quotaSelectedModels || []));
+		setFiltersExpanded(cfg.quotaFiltersExpanded || false);
+
 		if (props.authStatus.antigravity > 0) {
 			loadQuota();
 		}
 	});
+
+	// Debounced config save
+	let saveTimer: number | undefined;
+	createEffect(() => {
+		const mode = viewMode();
+		const accounts = Array.from(selectedAccounts());
+		const models = Array.from(selectedModels());
+		const filtersExp = filtersExpanded();
+
+		clearTimeout(saveTimer);
+		saveTimer = window.setTimeout(async () => {
+			const cfg = appStore.config();
+			await saveConfig({
+				...cfg,
+				quotaViewMode: mode,
+				quotaSelectedAccounts: accounts,
+				quotaSelectedModels: models,
+				quotaFiltersExpanded: filtersExp,
+			});
+		}, 500);
+	});
+
+	// Available accounts/models from quota data
+	const availableAccounts = createMemo(() =>
+		quotaData().map((q) => q.accountEmail)
+	);
+
+	const availableModels = createMemo(() => {
+		const models = new Set<string>();
+		quotaData().forEach((account) => {
+			account.quotas.forEach((quota) => models.add(quota.displayName));
+		});
+		return Array.from(models).sort();
+	});
+
+	// Group models by category/prefix for cleaner filter UI
+	const groupedModels = createMemo(() => {
+		const models = availableModels();
+		const groups: Record<string, string[]> = {};
+
+		for (const model of models) {
+			let category = "Other";
+			const lowerModel = model.toLowerCase();
+
+			if (lowerModel.startsWith("claude") || lowerModel.includes("claude")) {
+				category = "Claude";
+			} else if (lowerModel.startsWith("gemini") || lowerModel.includes("gemini")) {
+				category = "Gemini";
+			} else if (lowerModel.startsWith("gpt") || lowerModel.includes("gpt")) {
+				category = "GPT";
+			} else if (lowerModel.startsWith("chat_")) {
+				category = "Chat";
+			} else if (lowerModel.includes("thinking")) {
+				category = "Thinking";
+			}
+
+			if (!groups[category]) {
+				groups[category] = [];
+			}
+			groups[category].push(model);
+		}
+
+		// Sort categories and return as array of [category, models]
+		const order = ["Claude", "Gemini", "GPT", "Chat", "Thinking", "Other"];
+		return order
+			.filter((cat) => groups[cat] && groups[cat].length > 0)
+			.map((cat) => ({ category: cat, models: groups[cat].sort() }));
+	});
+
+	// Calculate dynamic chart height based on number of models
+	const getChartHeight = (modelCount: number) => {
+		const baseHeight = 48; // base height in pixels
+		const heightPerModel = 28; // height per model row
+		const minHeight = 120;
+		const maxHeight = 400;
+		return Math.min(maxHeight, Math.max(minHeight, baseHeight + modelCount * heightPerModel));
+	};
+
+	// Filtered quota data
+	const filteredQuotaData = createMemo(() => {
+		let data = quotaData();
+
+		// Filter by selected accounts
+		if (selectedAccounts().size > 0) {
+			data = data.filter((q) => selectedAccounts().has(q.accountEmail));
+		}
+
+		// Filter by selected models
+		if (selectedModels().size > 0) {
+			data = data
+				.map((account) => ({
+					...account,
+					quotas: account.quotas.filter((q) =>
+						selectedModels().has(q.displayName)
+					),
+				}))
+				.filter((account) => account.quotas.length > 0);
+		}
+
+		return data;
+	});
+
+	// Low quota warning (any model < 30%)
+	const hasLowQuota = createMemo(() =>
+		filteredQuotaData().some((account) =>
+			account.quotas.some((q) => q.remainingPercent < 30)
+		)
+	);
 
 	// Get color based on remaining percentage
 	const getQuotaColor = (percent: number) => {
@@ -1120,6 +1242,7 @@ function QuotaWidget(props: { authStatus: { antigravity: number } }) {
 
 	return (
 		<div class="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 overflow-hidden">
+			{/* Header */}
 			<div
 				onClick={() => setExpanded(!expanded())}
 				class="w-full flex items-center justify-between px-4 py-3 border-b border-gray-100 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors cursor-pointer"
@@ -1135,8 +1258,7 @@ function QuotaWidget(props: { authStatus: { antigravity: number } }) {
 					</span>
 					<Show when={quotaData().length > 0}>
 						<span class="text-xs text-gray-500 dark:text-gray-400">
-							({quotaData().length} account{quotaData().length !== 1 ? "s" : ""}
-							)
+							({quotaData().length} account{quotaData().length !== 1 ? "s" : ""})
 						</span>
 					</Show>
 				</div>
@@ -1255,27 +1377,195 @@ function QuotaWidget(props: { authStatus: { antigravity: number } }) {
 			</div>
 
 			<Show when={expanded()}>
+				{/* Filter Controls */}
+				<div class="border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50">
+					<button
+						onClick={() => setFiltersExpanded(!filtersExpanded())}
+						class="w-full px-4 py-2 flex items-center justify-between hover:bg-gray-100 dark:hover:bg-gray-700/50"
+					>
+						<span class="text-xs font-medium text-gray-600 dark:text-gray-400">
+							Filters & View
+						</span>
+						<svg
+							class={`w-3 h-3 text-gray-400 transition-transform ${filtersExpanded() ? "rotate-180" : ""}`}
+							fill="none"
+							stroke="currentColor"
+							viewBox="0 0 24 24"
+						>
+							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+						</svg>
+					</button>
+
+					<Show when={filtersExpanded()}>
+						<div class="px-4 py-3 space-y-3">
+							{/* View Mode Toggle */}
+							<div class="flex items-center gap-2">
+								<span class="text-xs text-gray-600 dark:text-gray-400">View:</span>
+								<button
+									onClick={() => setViewMode("chart")}
+									class={`px-3 py-1 text-xs rounded ${viewMode() === "chart" ? "bg-blue-500 text-white" : "bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300"}`}
+								>
+									Chart
+								</button>
+								<button
+									onClick={() => setViewMode("list")}
+									class={`px-3 py-1 text-xs rounded ${viewMode() === "list" ? "bg-blue-500 text-white" : "bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300"}`}
+								>
+									List
+								</button>
+							</div>
+
+							{/* Account Filter */}
+							<Show when={availableAccounts().length > 1}>
+								<div>
+									<p class="text-xs text-gray-500 dark:text-gray-400 mb-1">Accounts:</p>
+									<div class="flex flex-wrap gap-1">
+										<For each={availableAccounts()}>
+											{(account) => (
+												<label class="flex items-center gap-1 text-xs cursor-pointer">
+													<input
+														type="checkbox"
+														checked={selectedAccounts().has(account)}
+														onChange={(e) => {
+															const newSet = new Set(selectedAccounts());
+															if (e.currentTarget.checked) {
+																newSet.add(account);
+															} else {
+																newSet.delete(account);
+															}
+															setSelectedAccounts(newSet);
+														}}
+														class="rounded border-gray-300 w-3 h-3"
+													/>
+													<span class="text-gray-700 dark:text-gray-300 truncate max-w-[150px]">{account}</span>
+												</label>
+											)}
+										</For>
+									</div>
+								</div>
+							</Show>
+
+							{/* Model Filter - Grouped by Category */}
+							<Show when={groupedModels().length > 0}>
+								<div>
+									<div class="flex items-center justify-between mb-2">
+										<p class="text-xs text-gray-500 dark:text-gray-400">Models:</p>
+										<span class="text-[10px] text-gray-400">
+											{selectedModels().size > 0 ? `${selectedModels().size} selected` : "All"}
+										</span>
+									</div>
+									<div class="space-y-2 max-h-48 overflow-y-auto pr-1">
+										<For each={groupedModels()}>
+											{(group) => (
+												<div class="border border-gray-200 dark:border-gray-600 rounded-lg overflow-hidden">
+													<div class="flex items-center justify-between px-2 py-1.5 bg-gray-100 dark:bg-gray-700/50">
+														<span class="text-xs font-medium text-gray-700 dark:text-gray-300">
+															{group.category}
+														</span>
+														<button
+															onClick={() => {
+																const newSet = new Set(selectedModels());
+																const allSelected = group.models.every((m) => newSet.has(m));
+																if (allSelected) {
+																	group.models.forEach((m) => newSet.delete(m));
+																} else {
+																	group.models.forEach((m) => newSet.add(m));
+																}
+																setSelectedModels(newSet);
+															}}
+															class="text-[10px] text-blue-500 hover:text-blue-600 dark:text-blue-400 dark:hover:text-blue-300"
+														>
+															{group.models.every((m) => selectedModels().has(m)) ? "Deselect all" : "Select all"}
+														</button>
+													</div>
+													<div class="p-2 grid grid-cols-2 gap-1">
+														<For each={group.models}>
+															{(model) => (
+																<label class="flex items-center gap-1.5 text-xs cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700/30 rounded px-1 py-0.5">
+																	<input
+																		type="checkbox"
+																		checked={selectedModels().has(model)}
+																		onChange={(e) => {
+																			const newSet = new Set(selectedModels());
+																			if (e.currentTarget.checked) {
+																				newSet.add(model);
+																			} else {
+																				newSet.delete(model);
+																			}
+																			setSelectedModels(newSet);
+																		}}
+																		class="rounded border-gray-300 w-3 h-3 flex-shrink-0"
+																	/>
+																	<span class="text-gray-700 dark:text-gray-300 truncate" title={model}>
+																		{model.replace(/^(claude-|gemini-|gpt-|chat_)/, "")}
+																	</span>
+																</label>
+															)}
+														</For>
+													</div>
+												</div>
+											)}
+										</For>
+									</div>
+								</div>
+							</Show>
+
+							{/* Quick Filters */}
+							<div class="flex gap-2 pt-2 border-t border-gray-200 dark:border-gray-700">
+								<button
+									onClick={() => {
+										setSelectedAccounts(new Set<string>());
+										setSelectedModels(new Set<string>());
+									}}
+									class="text-xs px-2 py-1 bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded hover:bg-gray-300 dark:hover:bg-gray-600"
+								>
+									Show All
+								</button>
+								<button
+									onClick={() => {
+										const lowModels = new Set<string>();
+										quotaData().forEach((account) => {
+											account.quotas.forEach((quota) => {
+												if (quota.remainingPercent < 50) {
+													lowModels.add(quota.displayName);
+												}
+											});
+										});
+										setSelectedModels(lowModels);
+									}}
+									class="text-xs px-2 py-1 bg-yellow-500 text-white rounded hover:bg-yellow-600"
+								>
+									Low Quota (&lt;50%)
+								</button>
+							</div>
+						</div>
+					</Show>
+				</div>
+
+				{/* Low Quota Warning */}
+				<Show when={hasLowQuota()}>
+					<div class="mx-4 mt-3 p-3 bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-lg">
+						<div class="flex items-center gap-2">
+							<svg class="w-4 h-4 text-yellow-600 dark:text-yellow-400" fill="currentColor" viewBox="0 0 20 20">
+								<path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" />
+							</svg>
+							<span class="text-sm font-medium text-yellow-800 dark:text-yellow-300">
+								Low Quota Alert
+							</span>
+						</div>
+						<p class="mt-1 text-xs text-yellow-700 dark:text-yellow-400">
+							Some models have less than 30% quota remaining
+						</p>
+					</div>
+				</Show>
+
+				{/* Content Area */}
 				<div class="p-4 space-y-4">
 					<Show when={loading() && quotaData().length === 0}>
 						<div class="flex items-center justify-center py-4 text-gray-500">
-							<svg
-								class="w-5 h-5 animate-spin mr-2"
-								fill="none"
-								viewBox="0 0 24 24"
-							>
-								<circle
-									class="opacity-25"
-									cx="12"
-									cy="12"
-									r="10"
-									stroke="currentColor"
-									stroke-width="4"
-								/>
-								<path
-									class="opacity-75"
-									fill="currentColor"
-									d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-								/>
+							<svg class="w-5 h-5 animate-spin mr-2" fill="none" viewBox="0 0 24 24">
+								<circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+								<path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
 							</svg>
 							Loading quota...
 						</div>
@@ -1287,128 +1577,112 @@ function QuotaWidget(props: { authStatus: { antigravity: number } }) {
 						</div>
 					</Show>
 
-					<For each={quotaData()}>
-						{(account, index) => {
-							const [accountExpanded, setAccountExpanded] = createSignal(
-								index() === 0,
-							); // First account expanded by default
-							return (
-								<div class="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
-									<button
-										onClick={() => setAccountExpanded(!accountExpanded())}
-										class="w-full flex items-center justify-between px-3 py-2 bg-gray-50 dark:bg-gray-700/50 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
-									>
-										<span class="text-sm font-medium text-gray-700 dark:text-gray-300">
-											{account.accountEmail}
-										</span>
-										<div class="flex items-center gap-2">
-											<Show when={account.error}>
-												<span class="text-xs text-red-500">
-													{account.error}
-												</span>
-											</Show>
-											<Show when={!account.error}>
-												<span class="text-xs text-gray-500">
-													{filterQuotas(account.quotas).length}/
-													{account.quotas.length} models
-												</span>
-											</Show>
-											<svg
-												class={`w-4 h-4 text-gray-400 transition-transform ${accountExpanded() ? "rotate-180" : ""}`}
-												fill="none"
-												stroke="currentColor"
-												viewBox="0 0 24 24"
-											>
-												<path
-													stroke-linecap="round"
-													stroke-linejoin="round"
-													stroke-width="2"
-													d="M19 9l-7 7-7-7"
+					{/* Chart View */}
+					<Show when={viewMode() === "chart" && filteredQuotaData().length > 0}>
+						<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+							<For each={filteredQuotaData()}>
+								{(account) => (
+									<div class="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
+										<div class="px-3 py-2 bg-gray-50 dark:bg-gray-700/50 border-b border-gray-200 dark:border-gray-700">
+											<h4 class="text-sm font-medium text-gray-700 dark:text-gray-300 truncate">
+												{account.accountEmail}
+											</h4>
+											<p class="text-xs text-gray-500 dark:text-gray-400">
+												{account.quotas.length} models
+											</p>
+										</div>
+										<div class="p-3 bg-white dark:bg-gray-800">
+												<BarChart
+													data={account.quotas.map((q) => ({
+														name: q.displayName.replace(/^(gemini-|claude-|gpt-)/i, ""),
+														value: q.remainingPercent,
+														resetTime: q.resetTime,
+													}))}
+													horizontal={true}
+													colorByValue={true}
+													style={{ height: `${getChartHeight(account.quotas.length)}px` }}
 												/>
-											</svg>
-										</div>
-									</button>
+											</div>
+									</div>
+								)}
+							</For>
+						</div>
+					</Show>
 
-									<Show
-										when={
-											accountExpanded() &&
-											!account.error &&
-											filterQuotas(account.quotas).length > 0
-										}
-									>
-										<div class="p-3 space-y-2 bg-white dark:bg-gray-800">
-											<For each={filterQuotas(account.quotas)}>
-												{(quota) => (
-													<div class="space-y-1">
-														<div class="flex items-center justify-between text-xs">
-															<span class="text-gray-600 dark:text-gray-400">
-																{quota.displayName}
-															</span>
-															<span
-																class={getQuotaTextColor(
-																	quota.remainingPercent,
-																)}
-															>
-																{quota.remainingPercent.toFixed(0)}%
-															</span>
+					{/* List View */}
+					<Show when={viewMode() === "list" && filteredQuotaData().length > 0}>
+						<For each={filteredQuotaData()}>
+							{(account, index) => {
+								const [accountExpanded, setAccountExpanded] = createSignal(index() === 0);
+								return (
+									<div class="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
+										<button
+											onClick={() => setAccountExpanded(!accountExpanded())}
+											class="w-full flex items-center justify-between px-3 py-2 bg-gray-50 dark:bg-gray-700/50 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+										>
+											<span class="text-sm font-medium text-gray-700 dark:text-gray-300">
+												{account.accountEmail}
+											</span>
+											<div class="flex items-center gap-2">
+												<Show when={account.error}>
+													<span class="text-xs text-red-500">{account.error}</span>
+												</Show>
+												<Show when={!account.error}>
+													<span class="text-xs text-gray-500">{account.quotas.length} models</span>
+												</Show>
+												<svg
+													class={`w-4 h-4 text-gray-400 transition-transform ${accountExpanded() ? "rotate-180" : ""}`}
+													fill="none"
+													stroke="currentColor"
+													viewBox="0 0 24 24"
+												>
+													<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+												</svg>
+											</div>
+										</button>
+
+										<Show when={accountExpanded() && !account.error && account.quotas.length > 0}>
+											<div class="p-3 space-y-2 bg-white dark:bg-gray-800">
+												<For each={account.quotas}>
+													{(quota) => (
+														<div class="space-y-1">
+															<div class="flex items-center justify-between text-xs">
+																<span class="text-gray-600 dark:text-gray-400">{quota.displayName}</span>
+																<span class={getQuotaTextColor(quota.remainingPercent)}>
+																	{quota.remainingPercent.toFixed(0)}%
+																</span>
+															</div>
+															<div class="h-1.5 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden">
+																<div
+																	class={`h-full ${getQuotaColor(quota.remainingPercent)} transition-all duration-300`}
+																	style={{ width: `${Math.min(100, quota.remainingPercent)}%` }}
+																/>
+															</div>
+															<Show when={quota.resetTime}>
+																<p class="text-[10px] text-gray-400">
+																	Resets: {new Date(quota.resetTime!).toLocaleString()}
+																</p>
+															</Show>
 														</div>
-														<div class="h-1.5 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden">
-															<div
-																class={`h-full ${getQuotaColor(quota.remainingPercent)} transition-all duration-300`}
-																style={{
-																	width: `${Math.min(100, quota.remainingPercent)}%`,
-																}}
-															/>
-														</div>
-														<Show when={quota.resetTime}>
-															<p class="text-[10px] text-gray-400">
-																Resets:{" "}
-																{new Date(quota.resetTime!).toLocaleString()}
-															</p>
-														</Show>
-													</div>
-												)}
-											</For>
-										</div>
-									</Show>
+													)}
+												</For>
+											</div>
+										</Show>
 
-									<Show
-										when={
-											accountExpanded() &&
-											!account.error &&
-											account.quotas.length === 0
-										}
-									>
-										<div class="p-3 bg-white dark:bg-gray-800">
-											<p class="text-xs text-gray-500">
-												No quota data available
-											</p>
-										</div>
-									</Show>
+										<Show when={accountExpanded() && !account.error && account.quotas.length === 0}>
+											<div class="p-3 bg-white dark:bg-gray-800">
+												<p class="text-xs text-gray-500">No quota data available</p>
+											</div>
+										</Show>
+									</div>
+								);
+							}}
+						</For>
+					</Show>
 
-									{/* Show when all models are filtered out */}
-									<Show
-										when={
-											accountExpanded() &&
-											!account.error &&
-											account.quotas.length > 0 &&
-											filterQuotas(account.quotas).length === 0
-										}
-									>
-										<div class="p-3 bg-white dark:bg-gray-800">
-											<p class="text-xs text-gray-500">
-												All models hidden by filter
-											</p>
-										</div>
-									</Show>
-								</div>
-							);
-						}}
-					</For>
-
-					<Show when={!loading() && quotaData().length === 0 && !error()}>
+					<Show when={!loading() && filteredQuotaData().length === 0 && !error()}>
 						<p class="text-sm text-gray-500 text-center py-2">
-							No Antigravity accounts found
+							{quotaData().length === 0 ? "No Antigravity accounts found" : "No matching quota data"}
 						</p>
 					</Show>
 				</div>

--- a/src/stores/app.ts
+++ b/src/stores/app.ts
@@ -68,6 +68,10 @@ function createAppStore() {
 			rateLimit: undefined,
 			rateLimitWait: false,
 		},
+		quotaViewMode: "chart",
+		quotaSelectedAccounts: [],
+		quotaSelectedModels: [],
+		quotaFiltersExpanded: false,
 	});
 
 	// UI state


### PR DESCRIPTION
## Summary

Enhances the Antigravity QuotaWidget with better visualization and improved user experience.

## Changes

### QuotaWidget Improvements
- **Chart/List view toggle**: Users can switch between a visual bar chart and detailed list view
- **Inline percentage labels**: Percentages now display directly on the bars, eliminating the need to hover
- **Cleaner numbers**: Percentages rounded to 1 decimal place (e.g., `92.8%` instead of `92.80000000000001%`)
- **Shorter model names**: Provider prefixes (`gemini-`, `claude-`, `gpt-`) stripped from chart labels to save horizontal space
- **Color-coded bars**: Green (≥70%), yellow (30-69%), red (<30%) for quick status assessment
- **Dynamic sizing**: Chart height adjusts based on the number of models displayed

### BarChart Component
- Added `label` configuration with inside positioning
- Custom formatter function for percentage display with rounding
- Added `colorByValue` prop for quota-style color gradients

## Screenshots

<img width="994" height="772" alt="Screenshot 2025-12-25 at 14 43 20" src="https://github.com/user-attachments/assets/6067b606-ade8-462b-aa9e-03601f1256f6" />


<img width="998" height="777" alt="Screenshot 2025-12-25 at 14 44 03" src="https://github.com/user-attachments/assets/5542df7f-93db-4bb2-aeb7-d461837df8c5" />

<img width="362" height="163" alt="Screenshot 2025-12-25 at 17 09 54" src="https://github.com/user-attachments/assets/dac32fcf-95bf-4a52-81ba-3c09fe5dd6fe" />
