### PR TITLE
fix: update AMP Code model mappings to latest models

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3174,7 +3174,7 @@ dependencies = [
 
 [[package]]
 name = "proxypal"
-version = "0.3.69"
+version = "0.3.76"
 dependencies = [
  "chrono",
  "dirs 5.0.1",

--- a/src-tauri/scripts/download-binaries.ps1
+++ b/src-tauri/scripts/download-binaries.ps1
@@ -51,11 +51,19 @@ try {
 
     Expand-Archive -Path $ZipPath -DestinationPath $TempDir -Force
 
-    $SourceExe = Join-Path $TempDir "CLIProxyAPI.exe"
     $DestPath = Join-Path $BinariesDir $BinaryName
+    $CandidateExes = Get-ChildItem -Path $TempDir -Recurse -Filter *.exe | Where-Object {
+        $_.Name -match "CLIProxyAPI|cliproxyapi|cli-proxy-api"
+    }
 
-    if (Test-Path $SourceExe) {
-        Copy-Item -Path $SourceExe -Destination $DestPath -Force
+    if (-not $CandidateExes -or $CandidateExes.Count -eq 0) {
+        $CandidateExes = Get-ChildItem -Path $TempDir -Recurse -Filter *.exe
+    }
+
+    $SourceExe = $CandidateExes | Sort-Object FullName | Select-Object -First 1
+
+    if ($SourceExe) {
+        Copy-Item -Path $SourceExe.FullName -Destination $DestPath -Force
         Write-Host "Downloaded to $DestPath"
     } else {
         Write-Error "Binary not found in archive."

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -20,6 +20,11 @@ export async function getProxyStatus(): Promise<ProxyStatus> {
 	return invoke("get_proxy_status");
 }
 
+// GPT Reasoning Models (single source of truth from backend)
+export async function getGptReasoningModels(): Promise<string[]> {
+	return invoke("get_gpt_reasoning_models");
+}
+
 // OAuth management
 export type Provider =
 	| "claude"
@@ -115,42 +120,48 @@ export const AMP_MODEL_SLOTS: AmpModelSlot[] = [
 	{
 		id: "opus-4-5",
 		name: "Smart",
-		fromModel: "claude-opus-4-5-20251101", // Opus 4.5 (200K context)
-		fromLabel: "Claude Opus 4.5 (200K)",
+		fromModel: "claude-opus-4-5-20251101",
+		fromLabel: "Claude Opus 4.5",
 	},
-	// Claude Sonnet 4.5 - used by Librarian subagent
-	{
-		id: "sonnet-4-5",
-		name: "Librarian",
-		fromModel: "claude-sonnet-4-5-20250929", // Sonnet 4.5 (1M context)
-		fromLabel: "Claude Sonnet 4.5 (1M)",
-	},
-	// Claude Haiku 4.5 - used by Rush agent and Search subagent
+	// Claude Haiku 4.5 - used by Librarian, Rush, and Titling subagents
 	{
 		id: "haiku-4-5",
-		name: "Rush / Search",
-		fromModel: "claude-haiku-4-5-20251001", // Haiku 4.5
+		name: "Librarian/Rush/Titling",
+		fromModel: "claude-haiku-4-5-20251001",
 		fromLabel: "Claude Haiku 4.5",
 	},
-	// GPT-5.1 - used by Oracle agent
+	// Gemini 3 Flash - used by Search subagent
+	{
+		id: "search",
+		name: "Search",
+		fromModel: "gemini-3-flash-preview",
+		fromLabel: "Gemini 3 Flash",
+	},
+	// GPT-5.2 - used by Oracle agent
 	{
 		id: "oracle",
 		name: "Oracle",
-		fromModel: "gpt-5.1",
-		fromLabel: "GPT-5.1",
+		fromModel: "gpt-5.2",
+		fromLabel: "GPT-5.2",
 	},
-	// Gemini models for Review and Handoff
+	// Gemini models for Review, Handoff, and Topics
 	{
 		id: "review",
 		name: "Review",
-		fromModel: "gemini-2.5-flash-lite",
-		fromLabel: "Gemini 2.5 Flash-Lite",
+		fromModel: "gemini-3-pro-preview",
+		fromLabel: "Gemini 3 Pro",
 	},
 	{
 		id: "handoff",
 		name: "Handoff",
 		fromModel: "gemini-2.5-flash",
 		fromLabel: "Gemini 2.5 Flash",
+	},
+	{
+		id: "topics",
+		name: "Topics",
+		fromModel: "gemini-2.5-flash-lite-preview-09-2025",
+		fromLabel: "Gemini 2.5 Flash-Lite Preview",
 	},
 ];
 
@@ -161,8 +172,8 @@ export const AMP_MODEL_ALIASES: Record<string, string> = {
 	"claude-opus-4-5": "claude-opus-4-5-20251101",
 	"claude-haiku-4.5": "claude-haiku-4-5-20251001",
 	"claude-haiku-4-5": "claude-haiku-4-5-20251001",
-	"claude-sonnet-4.5": "claude-sonnet-4-5-20250929",
-	"claude-sonnet-4-5": "claude-sonnet-4-5-20250929",
+	"claude-sonnet-4.5": "claude-sonnet-4-5-20241022",
+	"claude-sonnet-4-5": "claude-sonnet-4-5-20241022",
 };
 
 // Complete list of GitHub Copilot models available via copilot-api


### PR DESCRIPTION
## Summary
Cập nhật tên model mapping cho AMP Code lên phiên bản mới nhất.

Closes #126

## Changes

### Model Slot Updates
| Slot | Trước | Sau |
|------|-------|-----|
| Oracle | GPT-5.1 | GPT-5.2 |
| Review | Gemini 2.5 Flash-Lite | Gemini 3 Pro |
| Librarian | Claude Sonnet 4.5 | Claude Haiku 4.5 (merged) |
| Rush/Search | Claude Haiku 4.5 | Split: Haiku 4.5 + Gemini 3 Flash |

### New Slots
- **Search**: Gemini 3 Flash Preview
- **Topics**: Gemini 2.5 Flash-Lite Preview

### Merged Slots
- **Librarian/Rush/Titling**: Gộp thành 1 slot dùng Claude Haiku 4.5
- Loại bỏ slot Sonnet 4.5 riêng (đã có Opus 4.5 cho Smart)

### GPT Reasoning Level Support
- Thêm UI control cho GPT reasoning suffix (`none`/`minimal`/`low`/`medium`/`high`/`xhigh`)
- Single source of truth: GPT-5 base models định nghĩa trong Rust backend
- Frontend lấy danh sách qua Tauri command `get_gpt_reasoning_models()`
- Tự động apply suffix như `gpt-5(high)` cho các mapping target GPT-5

## Files Changed
- `src-tauri/src/lib.rs` - Backend constants + new Tauri command
- `src/lib/tauri.ts` - Updated AMP_MODEL_SLOTS + aliases
- `src/pages/Settings.tsx` - GPT reasoning level UI + logic

## Testing
- [x] `pnpm tsc --noEmit` - Pass
- [x] `cargo check` - Pass
