### PR TITLE
fix: use CLIProxyAPIPlus repository in CI/CD workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Download CLIProxyAPI binary
+      - name: Download CLIProxyAPIPlus binary
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
@@ -144,9 +144,9 @@ jobs:
               ;;
           esac
 
-          echo "Downloading CLIProxyAPI for ${{ matrix.target }}..."
+          echo "Downloading CLIProxyAPIPlus for ${{ matrix.target }}..."
           cd /tmp
-          gh release download --repo router-for-me/CLIProxyAPI --pattern "$ASSET_PATTERN" --clobber
+          gh release download --repo router-for-me/CLIProxyAPIPlus --pattern "$ASSET_PATTERN" --clobber
 
           ARCHIVE=$(ls $ASSET_PATTERN 2>/dev/null | head -1)
           echo "Extracting $ARCHIVE..."
@@ -157,7 +157,18 @@ jobs:
             tar -xzf "$ARCHIVE"
           fi
 
-          if [ -f "CLIProxyAPI" ]; then
+          # CLIProxyAPIPlus binary detection (prioritize Plus naming, fallback to original)
+          if [ -f "cli-proxy-api-plus" ]; then
+            cp cli-proxy-api-plus "$GITHUB_WORKSPACE/src-tauri/binaries/$BINARY"
+            chmod +x "$GITHUB_WORKSPACE/src-tauri/binaries/$BINARY"
+          elif [ -f "cli-proxy-api-plus.exe" ]; then
+            cp cli-proxy-api-plus.exe "$GITHUB_WORKSPACE/src-tauri/binaries/$BINARY"
+          elif [ -f "CLIProxyAPIPlus" ]; then
+            cp CLIProxyAPIPlus "$GITHUB_WORKSPACE/src-tauri/binaries/$BINARY"
+            chmod +x "$GITHUB_WORKSPACE/src-tauri/binaries/$BINARY"
+          elif [ -f "CLIProxyAPIPlus.exe" ]; then
+            cp CLIProxyAPIPlus.exe "$GITHUB_WORKSPACE/src-tauri/binaries/$BINARY"
+          elif [ -f "CLIProxyAPI" ]; then
             cp CLIProxyAPI "$GITHUB_WORKSPACE/src-tauri/binaries/$BINARY"
             chmod +x "$GITHUB_WORKSPACE/src-tauri/binaries/$BINARY"
           elif [ -f "CLIProxyAPI.exe" ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Download CLIProxyAPI binary
+      - name: Download CLIProxyAPIPlus binary
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
@@ -95,9 +95,9 @@ jobs:
               ;;
           esac
 
-          echo "Downloading CLIProxyAPI for ${{ matrix.target }}..."
+          echo "Downloading CLIProxyAPIPlus for ${{ matrix.target }}..."
           cd /tmp
-          gh release download --repo router-for-me/CLIProxyAPI --pattern "$ASSET_PATTERN" --clobber
+          gh release download --repo router-for-me/CLIProxyAPIPlus --pattern "$ASSET_PATTERN" --clobber
 
           ARCHIVE=$(ls $ASSET_PATTERN 2>/dev/null | head -1)
           echo "Extracting $ARCHIVE..."
@@ -108,7 +108,18 @@ jobs:
             tar -xzf "$ARCHIVE"
           fi
 
-          if [ -f "CLIProxyAPI" ]; then
+          # CLIProxyAPIPlus binary detection (prioritize Plus naming, fallback to original)
+          if [ -f "cli-proxy-api-plus" ]; then
+            cp cli-proxy-api-plus "$GITHUB_WORKSPACE/src-tauri/binaries/$BINARY"
+            chmod +x "$GITHUB_WORKSPACE/src-tauri/binaries/$BINARY"
+          elif [ -f "cli-proxy-api-plus.exe" ]; then
+            cp cli-proxy-api-plus.exe "$GITHUB_WORKSPACE/src-tauri/binaries/$BINARY"
+          elif [ -f "CLIProxyAPIPlus" ]; then
+            cp CLIProxyAPIPlus "$GITHUB_WORKSPACE/src-tauri/binaries/$BINARY"
+            chmod +x "$GITHUB_WORKSPACE/src-tauri/binaries/$BINARY"
+          elif [ -f "CLIProxyAPIPlus.exe" ]; then
+            cp CLIProxyAPIPlus.exe "$GITHUB_WORKSPACE/src-tauri/binaries/$BINARY"
+          elif [ -f "CLIProxyAPI" ]; then
             cp CLIProxyAPI "$GITHUB_WORKSPACE/src-tauri/binaries/$BINARY"
             chmod +x "$GITHUB_WORKSPACE/src-tauri/binaries/$BINARY"
           elif [ -f "CLIProxyAPI.exe" ]; then


### PR DESCRIPTION
This commit fixes the mismatch between the advertised CLIProxyAPIPlus version in release notes and the actual binary bundled in ProxyPal.

Changes:
- Update `gh release download` to use `router-for-me/CLIProxyAPIPlus` instead of `router-for-me/CLIProxyAPI` in both release.yml and ci.yml
- Add CLIProxyAPIPlus binary name detection (cli-proxy-api-plus, CLIProxyAPIPlus) with priority over original naming
- Update step name to reflect the correct binary being downloaded

This ensures consistency between:
- Local build scripts (download-binaries.sh/ps1) which already use CLIProxyAPIPlus
- CI/CD workflows which were incorrectly using CLIProxyAPI

Fixes #151
Related to #145, #149