### PR TITLE
fix: align sidecar binary naming with tauri.conf.json externalBin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,8 @@ jobs:
       - name: Create placeholder binary for CI check
         run: |
           mkdir -p src-tauri/binaries
-          touch src-tauri/binaries/cliproxyapi-aarch64-apple-darwin
-          chmod +x src-tauri/binaries/cliproxyapi-aarch64-apple-darwin
+          touch src-tauri/binaries/cli-proxy-api-aarch64-apple-darwin
+          chmod +x src-tauri/binaries/cli-proxy-api-aarch64-apple-darwin
 
       - name: TypeScript check
         run: pnpm tsc --noEmit
@@ -120,22 +120,22 @@ jobs:
           case "${{ matrix.target }}" in
             aarch64-apple-darwin)
               ASSET_PATTERN="*darwin_arm64.tar.gz"
-              BINARY="cliproxyapi-aarch64-apple-darwin"
+              BINARY="cli-proxy-api-aarch64-apple-darwin"
               ARCHIVE_TYPE="tar"
               ;;
             x86_64-apple-darwin)
               ASSET_PATTERN="*darwin_amd64.tar.gz"
-              BINARY="cliproxyapi-x86_64-apple-darwin"
+              BINARY="cli-proxy-api-x86_64-apple-darwin"
               ARCHIVE_TYPE="tar"
               ;;
             x86_64-unknown-linux-gnu)
               ASSET_PATTERN="*linux_amd64.tar.gz"
-              BINARY="cliproxyapi-x86_64-unknown-linux-gnu"
+              BINARY="cli-proxy-api-x86_64-unknown-linux-gnu"
               ARCHIVE_TYPE="tar"
               ;;
             x86_64-pc-windows-msvc)
               ASSET_PATTERN="*windows_amd64.zip"
-              BINARY="cliproxyapi-x86_64-pc-windows-msvc.exe"
+              BINARY="cli-proxy-api-x86_64-pc-windows-msvc.exe"
               ARCHIVE_TYPE="zip"
               ;;
             *)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,22 +71,22 @@ jobs:
           case "${{ matrix.target }}" in
             aarch64-apple-darwin)
               ASSET_PATTERN="*darwin_arm64.tar.gz"
-              BINARY="cliproxyapi-aarch64-apple-darwin"
+              BINARY="cli-proxy-api-aarch64-apple-darwin"
               ARCHIVE_TYPE="tar"
               ;;
             x86_64-apple-darwin)
               ASSET_PATTERN="*darwin_amd64.tar.gz"
-              BINARY="cliproxyapi-x86_64-apple-darwin"
+              BINARY="cli-proxy-api-x86_64-apple-darwin"
               ARCHIVE_TYPE="tar"
               ;;
             x86_64-unknown-linux-gnu)
               ASSET_PATTERN="*linux_amd64.tar.gz"
-              BINARY="cliproxyapi-x86_64-unknown-linux-gnu"
+              BINARY="cli-proxy-api-x86_64-unknown-linux-gnu"
               ARCHIVE_TYPE="tar"
               ;;
             x86_64-pc-windows-msvc)
               ASSET_PATTERN="*windows_amd64.zip"
-              BINARY="cliproxyapi-x86_64-pc-windows-msvc.exe"
+              BINARY="cli-proxy-api-x86_64-pc-windows-msvc.exe"
               ARCHIVE_TYPE="zip"
               ;;
             *)

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -72,7 +72,7 @@ fn main() {
 }
 
 fn get_binary_name(target: &str) -> String {
-    let base_name = "cliproxyapi";
+    let base_name = "cli-proxy-api";
     
     // Map Rust target triples to our binary naming convention
     let suffix = match target {

--- a/src-tauri/scripts/download-binaries.sh
+++ b/src-tauri/scripts/download-binaries.sh
@@ -93,10 +93,10 @@ if [ -n "$BINARY_NAME" ]; then
 else
 	# Download all binaries
 	for target in \
-		"cliproxyapi-aarch64-apple-darwin" \
-		"cliproxyapi-x86_64-apple-darwin" \
-		"cliproxyapi-x86_64-unknown-linux-gnu" \
-		"cliproxyapi-x86_64-pc-windows-msvc.exe"; do
+		"cli-proxy-api-aarch64-apple-darwin" \
+		"cli-proxy-api-x86_64-apple-darwin" \
+		"cli-proxy-api-x86_64-unknown-linux-gnu" \
+		"cli-proxy-api-x86_64-pc-windows-msvc.exe"; do
 		if [ ! -f "$BINARIES_DIR/$target" ]; then
 			"$0" "$target" || echo "Warning: Failed to download $target"
 		fi


### PR DESCRIPTION
CRITICAL BUG FIX: The release workflow was saving downloaded binaries with the wrong filename prefix, causing Tauri to bundle old cached binaries instead of freshly downloaded ones.

Root cause:
- tauri.conf.json specifies: externalBin = 'binaries/cli-proxy-api'
- Tauri expects files named: cli-proxy-api-{target}
- But workflows saved them as: cliproxyapi-{target}
- Old binaries named cli-proxy-api-* existed in the repo
- Tauri found and used the OLD binaries (v6.6.57-next from Dec 2025)

This fix aligns all naming to use 'cli-proxy-api-{target}' consistently:
- .github/workflows/release.yml: BINARY variable
- .github/workflows/ci.yml: BINARY variable and placeholder
- src-tauri/build.rs: base_name constant
- src-tauri/scripts/download-binaries.sh: default targets list

Fixes #149
Related to #151