### PR TITLE
fix(amp-mapping): support opus 4.6 and codex 5.3 reasoning

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -62,6 +62,8 @@ const GPT5_BASE_MODELS: &[&str] = &[
     "gpt-5.1-codex-max",
     "gpt-5.2",
     "gpt-5.2-codex",
+    "gpt-5.3",
+    "gpt-5.3-codex",
 ];
 
 // GPT-5 reasoning level suffixes

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -118,12 +118,12 @@ export interface AmpModelSlot {
 // IMPORTANT: Model names must match EXACTLY what Amp sends in requests
 // NOTE: When using Copilot provider, these get mapped to copilot-prefixed models
 export const AMP_MODEL_SLOTS: AmpModelSlot[] = [
-	// Claude Opus 4.5 - used by Smart agent (default main agent)
+	// Claude Opus 4.6 - used by Smart agent (default main agent)
 	{
-		id: "opus-4-5",
+		id: "opus-4-6",
 		name: "Smart",
-		fromModel: "claude-opus-4-5-20251101",
-		fromLabel: "Claude Opus 4.5",
+		fromModel: "claude-opus-4-6",
+		fromLabel: "Claude Opus 4.6",
 	},
 	// Claude Haiku 4.5 - used by Librarian, Rush, and Titling subagents
 	{
@@ -170,8 +170,8 @@ export const AMP_MODEL_SLOTS: AmpModelSlot[] = [
 // Common model aliases that Amp might use (without date suffix)
 // These map to the full model identifiers
 export const AMP_MODEL_ALIASES: Record<string, string> = {
-	"claude-opus-4.5": "claude-opus-4-5-20251101",
-	"claude-opus-4-5": "claude-opus-4-5-20251101",
+	"claude-opus-4.6": "claude-opus-4-6",
+	"claude-opus-4-6": "claude-opus-4-6",
 	"claude-haiku-4.5": "claude-haiku-4-5-20251001",
 	"claude-haiku-4-5": "claude-haiku-4-5-20251001",
 	"claude-sonnet-4.5": "claude-sonnet-4-5-20241022",


### PR DESCRIPTION
- update amp smart slot mapping identifiers to claude-opus-4-6 and normalize the related amp alias mapping.
- extend gpt reasoning base models with gpt-5.3 and gpt-5.3-codex so thinking-level suffix handling applies correctly when mapping to codex 5.3.


<img width="571" height="136" alt="image" src="https://github.com/user-attachments/assets/22c8e08e-94be-478d-b44f-8203391a8d44" />
