### PR TITLE
Add GPT-5.5 options to OpenAI model selectors

### DIFF
--- a/src/components/settings/AdvancedSettings.tsx
+++ b/src/components/settings/AdvancedSettings.tsx
@@ -356,6 +356,8 @@ export function AdvancedSettings(props: AdvancedSettingsProps) {
         { label: "gpt-5", value: "gpt-5" },
         { label: "gpt-5.1", value: "gpt-5.1" },
         { label: "gpt-5.2", value: "gpt-5.2" },
+        { label: "gpt-5.5", value: "gpt-5.5" },
+        { label: "gpt-5.5-fast", value: "gpt-5.5-fast" },
         { label: "gpt-5-codex", value: "gpt-5-codex" },
         { label: "gpt-5-codex-mini", value: "gpt-5-codex-mini" },
         { label: "gpt-5.1-codex", value: "gpt-5.1-codex" },

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -244,6 +244,8 @@ export function SettingsPage() {
         { label: "gpt-5", value: "gpt-5" },
         { label: "gpt-5.1", value: "gpt-5.1" },
         { label: "gpt-5.2", value: "gpt-5.2" },
+        { label: "gpt-5.5", value: "gpt-5.5" },
+        { label: "gpt-5.5-fast", value: "gpt-5.5-fast" },
         // GPT-5 Codex models
         { label: "gpt-5-codex", value: "gpt-5-codex" },
         { label: "gpt-5-codex-mini", value: "gpt-5-codex-mini" },


### PR DESCRIPTION
﻿## Summary
Syncs the OpenAI model selectors with existing GPT-5.5 backend support.

## Validation
- pnpm tsc --noEmit
- cargo check
