### PR TITLE
fix: preserve API key prefixes and multiple keys across restarts

### DIFF
--- a/src-tauri/src/commands/api_keys.rs
+++ b/src-tauri/src/commands/api_keys.rs
@@ -573,6 +573,9 @@ pub async fn set_openai_compatible_providers(
     // Persist to local config for restart persistence
     {
         let mut config = state.config.lock().unwrap();
+        // Full rich format (API Keys page)
+        config.openai_compatible_providers = normalized_providers.clone();
+        // Backward compat: also write flattened format (Settings page)
         config.amp_openai_providers = normalized_providers
             .iter()
             .map(|p| crate::types::amp::AmpOpenAIProvider {

--- a/src-tauri/src/commands/proxy.rs
+++ b/src-tauri/src/commands/proxy.rs
@@ -187,27 +187,87 @@ fn build_proxy_url_line(config: &AppConfig) -> String {
 fn build_openai_compat_section(config: &AppConfig) -> String {
     let mut entries = Vec::new();
 
-    // Custom providers
-    for provider in &config.amp_openai_providers {
-        if !provider.name.is_empty()
-            && !provider.base_url.is_empty()
-            && !provider.api_key.is_empty()
-        {
-            let mut entry = format!("  # Custom OpenAI-compatible provider: {}\n", provider.name);
+    // Prefer the rich format (API Keys page) when available
+    if !config.openai_compatible_providers.is_empty() {
+        for provider in &config.openai_compatible_providers {
+            if provider.name.is_empty() || provider.base_url.is_empty() {
+                continue;
+            }
+            if provider.api_key_entries.is_empty()
+                || provider.api_key_entries.iter().all(|e| e.api_key.is_empty())
+            {
+                continue;
+            }
+            let mut entry =
+                format!("  # OpenAI-compatible provider: {}\n", provider.name);
             entry.push_str(&format!("  - name: \"{}\"\n", provider.name));
             entry.push_str(&format!("    base-url: \"{}\"\n", provider.base_url));
             entry.push_str("    schema-cleaner: true\n");
+            if let Some(ref prefix) = provider.prefix {
+                if !prefix.is_empty() {
+                    entry.push_str(&format!("    prefix: \"{}\"\n", prefix));
+                }
+            }
+            if let Some(ref headers) = provider.headers {
+                if !headers.is_empty() {
+                    entry.push_str("    headers:\n");
+                    for (name, value) in headers {
+                        entry.push_str(&format!("      {}: \"{}\"\n", name, value));
+                    }
+                }
+            }
             entry.push_str("    api-key-entries:\n");
-            entry.push_str(&format!("      - api-key: \"{}\"\n", provider.api_key));
-
-            if !provider.models.is_empty() {
-                entry.push_str("    models:\n");
-                for model in &provider.models {
-                    entry.push_str(&format!("      - alias: \"{}\"\n", model.alias));
-                    entry.push_str(&format!("        name: \"{}\"\n", model.name));
+            for key_entry in &provider.api_key_entries {
+                if key_entry.api_key.is_empty() {
+                    continue;
+                }
+                entry.push_str(&format!("      - api-key: \"{}\"\n", key_entry.api_key));
+                if let Some(ref proxy_url) = key_entry.proxy_url {
+                    if !proxy_url.is_empty() {
+                        entry.push_str(&format!("        proxy-url: \"{}\"\n", proxy_url));
+                    }
+                }
+            }
+            if let Some(ref models) = provider.models {
+                if !models.is_empty() {
+                    entry.push_str("    models:\n");
+                    for model in models {
+                        let alias = model
+                            .alias
+                            .as_deref()
+                            .filter(|a| !a.is_empty())
+                            .unwrap_or(&model.name);
+                        entry.push_str(&format!("      - alias: \"{}\"\n", alias));
+                        entry.push_str(&format!("        name: \"{}\"\n", model.name));
+                    }
                 }
             }
             entries.push(entry);
+        }
+    } else {
+        // Fall back to legacy flat format (Settings page)
+        for provider in &config.amp_openai_providers {
+            if !provider.name.is_empty()
+                && !provider.base_url.is_empty()
+                && !provider.api_key.is_empty()
+            {
+                let mut entry =
+                    format!("  # Custom OpenAI-compatible provider: {}\n", provider.name);
+                entry.push_str(&format!("  - name: \"{}\"\n", provider.name));
+                entry.push_str(&format!("    base-url: \"{}\"\n", provider.base_url));
+                entry.push_str("    schema-cleaner: true\n");
+                entry.push_str("    api-key-entries:\n");
+                entry.push_str(&format!("      - api-key: \"{}\"\n", provider.api_key));
+
+                if !provider.models.is_empty() {
+                    entry.push_str("    models:\n");
+                    for model in &provider.models {
+                        entry.push_str(&format!("      - alias: \"{}\"\n", model.alias));
+                        entry.push_str(&format!("        name: \"{}\"\n", model.name));
+                    }
+                }
+                entries.push(entry);
+            }
         }
     }
 
@@ -294,6 +354,11 @@ fn build_claude_api_key_section(config: &AppConfig) -> String {
                 entry.push_str(&format!("    proxy-url: \"{}\"\n", proxy_url));
             }
         }
+        if let Some(ref prefix) = key.prefix {
+            if !prefix.is_empty() {
+                entry.push_str(&format!("    prefix: \"{}\"\n", prefix));
+            }
+        }
         entries.push(entry);
     }
 
@@ -325,6 +390,11 @@ fn build_gemini_api_key_section(config: &AppConfig) -> String {
                 section.push_str(&format!("    proxy-url: \"{}\"\n", proxy_url));
             }
         }
+        if let Some(ref prefix) = key.prefix {
+            if !prefix.is_empty() {
+                section.push_str(&format!("    prefix: \"{}\"\n", prefix));
+            }
+        }
     }
     section.push('\n');
     section
@@ -343,6 +413,11 @@ fn build_codex_api_key_section(config: &AppConfig) -> String {
         if let Some(ref proxy_url) = key.proxy_url {
             if !proxy_url.is_empty() {
                 section.push_str(&format!("    proxy-url: \"{}\"\n", proxy_url));
+            }
+        }
+        if let Some(ref prefix) = key.prefix {
+            if !prefix.is_empty() {
+                section.push_str(&format!("    prefix: \"{}\"\n", prefix));
             }
         }
     }

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -5,7 +5,8 @@ use uuid::Uuid;
 
 use crate::types::{
     amp::generate_uuid, cloudflare::CloudflareConfig, AmpModelMapping, AmpOpenAIProvider,
-    ClaudeApiKey, CodexApiKey, CopilotConfig, GeminiApiKey, SshConfig, VertexApiKey, XaiApiKey,
+    ClaudeApiKey, CodexApiKey, CopilotConfig, GeminiApiKey, OpenAICompatibleProvider, SshConfig,
+    VertexApiKey, XaiApiKey,
 };
 
 /// App configuration persisted to config.json
@@ -91,6 +92,8 @@ pub struct AppConfig {
     pub locale: String,
     #[serde(default)]
     pub ssh_configs: Vec<SshConfig>,
+    #[serde(default)]
+    pub openai_compatible_providers: Vec<OpenAICompatibleProvider>,
     #[serde(default)]
     pub cloudflare_configs: Vec<CloudflareConfig>,
     #[serde(default = "default_disable_control_panel")]
@@ -189,6 +192,7 @@ impl Default for AppConfig {
             ws_auth: true,
             locale: "en".to_string(),
             ssh_configs: Vec::new(),
+            openai_compatible_providers: Vec::new(),
             cloudflare_configs: Vec::new(),
             disable_control_panel: true,
         }

--- a/src/lib/tauri/config.ts
+++ b/src/lib/tauri/config.ts
@@ -1,6 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 
-import type { XaiApiKey } from "./api-keys";
+import type { OpenAICompatibleProvider, XaiApiKey } from "./api-keys";
 import type { CloudflareConfig } from "./cloudflare";
 import type { AmpOpenAIProvider, CopilotConfig } from "./models";
 import type { SshConfig } from "./ssh";
@@ -22,6 +22,7 @@ export interface AppConfig {
   ampRoutingMode?: string;
   autoStart: boolean;
   cloudflareConfigs?: CloudflareConfig[];
+  openaiCompatibleProviders?: OpenAICompatibleProvider[];
   commercialMode?: boolean;
   copilot: CopilotConfig;
   debug: boolean;


### PR DESCRIPTION
## Problem

After restarting ProxyPal, API key configuration set via the **API Keys** page was corrupted:

- **OpenAI Compatible providers**: multiple keys collapsed into one, `prefix` lost, `headers` and per-key `proxyUrl` dropped
- **Claude, Gemini, Codex**: `prefix` silently dropped after restart

Data looked correct while the proxy was running (Management API), but after restart the config was permanently damaged.

## Root Cause

Two bugs:

### 1. Persistence (`api_keys.rs`)
`set_openai_compatible_providers()` converted `OpenAICompatibleProvider` (rich: `apiKeyEntries[]`, `prefix`, `headers`) → `AmpOpenAIProvider` (flat: single `api_key`, no `prefix`). Only the first key survived.

### 2. YAML generator (`proxy.rs`)
On restart, proxy YAML is regenerated from `config.json`. Several builders omitted fields:

| Builder | Missing |
|---|---|
| `build_openai_compat_section` | `prefix`, keys after first, `headers`, per-key `proxyUrl` |
| `build_claude_api_key_section` | `prefix` |
| `build_gemini_api_key_section` | `prefix` |
| `build_codex_api_key_section` | `prefix` |

xAI and Vertex already handled `prefix` — untouched.

## Fix

4 files changed, 99 insertions, 16 deletions:

- **`src-tauri/src/config.rs`** — added `openai_compatible_providers` to `AppConfig` (full struct persistence)
- **`src-tauri/src/commands/api_keys.rs`** — persist full normalized providers to new field (keep legacy for Settings compat)
- **`src-tauri/src/commands/proxy.rs`** — `build_openai_compat_section` prefers rich format; added `prefix` to Claude, Gemini, Codex builders
- **`src/lib/tauri/config.ts`** — added `openaiCompatibleProviders` to TS interface

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for rich OpenAI-compatible provider configurations, including custom headers, multiple API keys, proxy URLs, prefixes, model aliases, and model lists.
  * Preserved compatibility with existing provider configurations through automatic fallback handling.
  * Added prefix support for Claude, Gemini, and Codex API key configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->