### PR TITLE
fix: macOS tray Dock/black-window + API key prefix & multi-key persistence

### DIFF
--- a/src-tauri/src/commands/api_keys.rs
+++ b/src-tauri/src/commands/api_keys.rs
@@ -573,6 +573,9 @@ pub async fn set_openai_compatible_providers(
     // Persist to local config for restart persistence
     {
         let mut config = state.config.lock().unwrap();
+        // Full rich format (API Keys page)
+        config.openai_compatible_providers = normalized_providers.clone();
+        // Backward compat: also write flattened format (Settings page)
         config.amp_openai_providers = normalized_providers
             .iter()
             .map(|p| crate::types::amp::AmpOpenAIProvider {

--- a/src-tauri/src/commands/proxy.rs
+++ b/src-tauri/src/commands/proxy.rs
@@ -187,27 +187,87 @@ fn build_proxy_url_line(config: &AppConfig) -> String {
 fn build_openai_compat_section(config: &AppConfig) -> String {
     let mut entries = Vec::new();
 
-    // Custom providers
-    for provider in &config.amp_openai_providers {
-        if !provider.name.is_empty()
-            && !provider.base_url.is_empty()
-            && !provider.api_key.is_empty()
-        {
-            let mut entry = format!("  # Custom OpenAI-compatible provider: {}\n", provider.name);
+    // Prefer the rich format (API Keys page) when available
+    if !config.openai_compatible_providers.is_empty() {
+        for provider in &config.openai_compatible_providers {
+            if provider.name.is_empty() || provider.base_url.is_empty() {
+                continue;
+            }
+            if provider.api_key_entries.is_empty()
+                || provider.api_key_entries.iter().all(|e| e.api_key.is_empty())
+            {
+                continue;
+            }
+            let mut entry =
+                format!("  # OpenAI-compatible provider: {}\n", provider.name);
             entry.push_str(&format!("  - name: \"{}\"\n", provider.name));
             entry.push_str(&format!("    base-url: \"{}\"\n", provider.base_url));
             entry.push_str("    schema-cleaner: true\n");
+            if let Some(ref prefix) = provider.prefix {
+                if !prefix.is_empty() {
+                    entry.push_str(&format!("    prefix: \"{}\"\n", prefix));
+                }
+            }
+            if let Some(ref headers) = provider.headers {
+                if !headers.is_empty() {
+                    entry.push_str("    headers:\n");
+                    for (name, value) in headers {
+                        entry.push_str(&format!("      {}: \"{}\"\n", name, value));
+                    }
+                }
+            }
             entry.push_str("    api-key-entries:\n");
-            entry.push_str(&format!("      - api-key: \"{}\"\n", provider.api_key));
-
-            if !provider.models.is_empty() {
-                entry.push_str("    models:\n");
-                for model in &provider.models {
-                    entry.push_str(&format!("      - alias: \"{}\"\n", model.alias));
-                    entry.push_str(&format!("        name: \"{}\"\n", model.name));
+            for key_entry in &provider.api_key_entries {
+                if key_entry.api_key.is_empty() {
+                    continue;
+                }
+                entry.push_str(&format!("      - api-key: \"{}\"\n", key_entry.api_key));
+                if let Some(ref proxy_url) = key_entry.proxy_url {
+                    if !proxy_url.is_empty() {
+                        entry.push_str(&format!("        proxy-url: \"{}\"\n", proxy_url));
+                    }
+                }
+            }
+            if let Some(ref models) = provider.models {
+                if !models.is_empty() {
+                    entry.push_str("    models:\n");
+                    for model in models {
+                        let alias = model
+                            .alias
+                            .as_deref()
+                            .filter(|a| !a.is_empty())
+                            .unwrap_or(&model.name);
+                        entry.push_str(&format!("      - alias: \"{}\"\n", alias));
+                        entry.push_str(&format!("        name: \"{}\"\n", model.name));
+                    }
                 }
             }
             entries.push(entry);
+        }
+    } else {
+        // Fall back to legacy flat format (Settings page)
+        for provider in &config.amp_openai_providers {
+            if !provider.name.is_empty()
+                && !provider.base_url.is_empty()
+                && !provider.api_key.is_empty()
+            {
+                let mut entry =
+                    format!("  # Custom OpenAI-compatible provider: {}\n", provider.name);
+                entry.push_str(&format!("  - name: \"{}\"\n", provider.name));
+                entry.push_str(&format!("    base-url: \"{}\"\n", provider.base_url));
+                entry.push_str("    schema-cleaner: true\n");
+                entry.push_str("    api-key-entries:\n");
+                entry.push_str(&format!("      - api-key: \"{}\"\n", provider.api_key));
+
+                if !provider.models.is_empty() {
+                    entry.push_str("    models:\n");
+                    for model in &provider.models {
+                        entry.push_str(&format!("      - alias: \"{}\"\n", model.alias));
+                        entry.push_str(&format!("        name: \"{}\"\n", model.name));
+                    }
+                }
+                entries.push(entry);
+            }
         }
     }
 
@@ -294,6 +354,11 @@ fn build_claude_api_key_section(config: &AppConfig) -> String {
                 entry.push_str(&format!("    proxy-url: \"{}\"\n", proxy_url));
             }
         }
+        if let Some(ref prefix) = key.prefix {
+            if !prefix.is_empty() {
+                entry.push_str(&format!("    prefix: \"{}\"\n", prefix));
+            }
+        }
         entries.push(entry);
     }
 
@@ -325,6 +390,11 @@ fn build_gemini_api_key_section(config: &AppConfig) -> String {
                 section.push_str(&format!("    proxy-url: \"{}\"\n", proxy_url));
             }
         }
+        if let Some(ref prefix) = key.prefix {
+            if !prefix.is_empty() {
+                section.push_str(&format!("    prefix: \"{}\"\n", prefix));
+            }
+        }
     }
     section.push('\n');
     section
@@ -343,6 +413,11 @@ fn build_codex_api_key_section(config: &AppConfig) -> String {
         if let Some(ref proxy_url) = key.proxy_url {
             if !proxy_url.is_empty() {
                 section.push_str(&format!("    proxy-url: \"{}\"\n", proxy_url));
+            }
+        }
+        if let Some(ref prefix) = key.prefix {
+            if !prefix.is_empty() {
+                section.push_str(&format!("    prefix: \"{}\"\n", prefix));
             }
         }
     }

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -5,7 +5,8 @@ use uuid::Uuid;
 
 use crate::types::{
     amp::generate_uuid, cloudflare::CloudflareConfig, AmpModelMapping, AmpOpenAIProvider,
-    ClaudeApiKey, CodexApiKey, CopilotConfig, GeminiApiKey, SshConfig, VertexApiKey, XaiApiKey,
+    ClaudeApiKey, CodexApiKey, CopilotConfig, GeminiApiKey, OpenAICompatibleProvider, SshConfig,
+    VertexApiKey, XaiApiKey,
 };
 
 /// App configuration persisted to config.json
@@ -91,6 +92,8 @@ pub struct AppConfig {
     pub locale: String,
     #[serde(default)]
     pub ssh_configs: Vec<SshConfig>,
+    #[serde(default)]
+    pub openai_compatible_providers: Vec<OpenAICompatibleProvider>,
     #[serde(default)]
     pub cloudflare_configs: Vec<CloudflareConfig>,
     #[serde(default = "default_disable_control_panel")]
@@ -189,6 +192,7 @@ impl Default for AppConfig {
             ws_auth: true,
             locale: "en".to_string(),
             ssh_configs: Vec::new(),
+            openai_compatible_providers: Vec::new(),
             cloudflare_configs: Vec::new(),
             disable_control_panel: true,
         }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -123,12 +123,48 @@ fn handle_deep_link(app: &tauri::AppHandle, urls: Vec<url::Url>) {
             }
 
             // Bring window to front
-            if let Some(window) = app.get_webview_window("main") {
-                let _ = window.unminimize();
-                let _ = window.show();
-                let _ = window.set_focus();
-            }
+            show_main_window(app);
         }
+    }
+}
+
+// macOS tray-app lifecycle helpers. Per Tauri best practices (see
+// https://dev.to/hiyoyok/complete-guide-to-building-a-macos-menu-bar-app-with-tauri-v2-aji
+// and Tauri 2.10 AppHandle docs):
+//   show → set_dock_visibility(true) + app.show() + window.show + focus
+//   hide → window.hide() + app.hide() + set_dock_visibility(false)
+// app.show()/hide() call NSApplication.show()/hide() so the app vanishes
+// from Mission Control and the app switcher when in tray, and WKWebView
+// backing store refills on show (fixes black window).
+
+// Show the main window and focus it. On macOS, reveals the Dock icon,
+// restores NSApplication (fixing WKWebView stale backing store), then
+// unminimizes, shows, and focuses the window.
+#[allow(dead_code)]
+fn show_main_window(app: &tauri::AppHandle) {
+    #[cfg(target_os = "macos")]
+    {
+        let _ = app.set_dock_visibility(true);
+        let _ = app.show();
+    }
+    if let Some(window) = app.get_webview_window("main") {
+        let _ = window.unminimize();
+        let _ = window.show();
+        let _ = window.set_focus();
+    }
+}
+
+// Hide the main window and, on macOS, the whole NSApplication.
+// Removes the Dock icon and hides from Mission Control / app switcher.
+#[allow(dead_code)]
+fn hide_main_window(app: &tauri::AppHandle) {
+    if let Some(window) = app.get_webview_window("main") {
+        let _ = window.hide();
+    }
+    #[cfg(target_os = "macos")]
+    {
+        let _ = app.hide();
+        let _ = app.set_dock_visibility(false);
     }
 }
 
@@ -165,11 +201,7 @@ fn setup_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
                 let _ = app.emit("tray-toggle-proxy", !is_running);
             }
             "dashboard" => {
-                if let Some(window) = app.get_webview_window("main") {
-                    let _ = window.unminimize();
-                    let _ = window.show();
-                    let _ = window.set_focus();
-                }
+                show_main_window(app);
             }
             "quit" => {
                 app.exit(0);
@@ -184,11 +216,7 @@ fn setup_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
             } = event
             {
                 let app = tray.app_handle();
-                if let Some(window) = app.get_webview_window("main") {
-                    let _ = window.unminimize();
-                    let _ = window.show();
-                    let _ = window.set_focus();
-                }
+                show_main_window(app);
             }
         })
         .build(app)?;
@@ -300,11 +328,7 @@ pub fn run() {
             }
 
             // Show existing window
-            if let Some(window) = app.get_webview_window("main") {
-                let _ = window.unminimize();
-                let _ = window.show();
-                let _ = window.set_focus();
-            }
+            show_main_window(app);
         }))
         .manage(app_state)
         .manage(SshManager::new())
@@ -519,10 +543,8 @@ pub fn run() {
 
                             if close_to_tray {
                                 // Hide to tray instead of closing
-                                if let Some(window) = app_handle.get_webview_window("main") {
-                                    println!("[ProxyPal] Hiding to system tray...");
-                                    let _ = window.hide();
-                                }
+                                println!("[ProxyPal] Hiding to system tray...");
+                                hide_main_window(app_handle);
                                 api.prevent_close();
                             }
                             // If close_to_tray is false, allow normal close behavior

--- a/src/lib/tauri/config.ts
+++ b/src/lib/tauri/config.ts
@@ -1,6 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 
-import type { XaiApiKey } from "./api-keys";
+import type { OpenAICompatibleProvider, XaiApiKey } from "./api-keys";
 import type { CloudflareConfig } from "./cloudflare";
 import type { AmpOpenAIProvider, CopilotConfig } from "./models";
 import type { SshConfig } from "./ssh";
@@ -22,6 +22,7 @@ export interface AppConfig {
   ampRoutingMode?: string;
   autoStart: boolean;
   cloudflareConfigs?: CloudflareConfig[];
+  openaiCompatibleProviders?: OpenAICompatibleProvider[];
   commercialMode?: boolean;
   copilot: CopilotConfig;
   debug: boolean;


### PR DESCRIPTION
Two independent bug fixes from a downstream fork (v0.4.47 build testing on macOS x86_64). Both are on top of the `e169cdc` xAI provider commit.

---

## Fix 1 — Preserve API key prefixes and multiple keys across restarts

**Commit:** `2f71ca3`

### Problem
Two related bugs caused silent data loss on app restart for OpenAI-compatible providers, and prefix loss for Claude / Gemini / Codex providers.

**Bug 1 — Persistence layer (`commands/api_keys.rs`):**
`set_openai_compatible_providers()` converted the rich `OpenAICompatibleProvider` struct (`apiKeyEntries[]`, `prefix`, `headers`, per-key `proxy_url`) into the legacy flat `AmpOpenAIProvider` (single `api_key` string, no `prefix`, no `headers`). Only the **first** key was persisted; all other keys and the prefix were silently dropped from `config.json`. After a restart the proxy YAML was regenerated from the truncated config, so the keys were effectively gone.

**Bug 2 — YAML config generator (`commands/proxy.rs`):**
After restart the proxy YAML is regenerated from `config.json`. Several builder functions omitted the `prefix` field:
- `build_openai_compat_section` — only one key, no `prefix`, no `headers`
- `build_claude_api_key_section` — no `prefix`
- `build_gemini_api_key_section` — no `prefix`
- `build_codex_api_key_section` — no `prefix`

### Fix
- `config.rs`: add `openai_compatible_providers: Vec<OpenAICompatibleProvider>` to `AppConfig` so the full structured data survives in `config.json` (legacy `amp_openai_providers` kept for backward compat).
- `api_keys.rs`: `set_openai_compatible_providers` now persists the full normalized providers into the new field in addition to the legacy flat field.
- `proxy.rs`: `build_openai_compat_section` prefers the rich format when available, emitting all `api-key-entries`, `prefix`, `headers`, and per-key `proxy_url`. Added `prefix` output to the Claude, Gemini, and Codex section builders.
- `src/lib/tauri/config.ts`: add `openaiCompatibleProviders` to the TypeScript `AppConfig`.

xAI and Vertex already handled `prefix` correctly and were not touched.

**Files:** `src-tauri/src/commands/api_keys.rs`, `src-tauri/src/commands/proxy.rs`, `src-tauri/src/config.rs`, `src/lib/tauri/config.ts` (+99 / -16)

---

## Fix 2 — macOS tray Dock icon + black window (Tauri native API)

**Commit:** `4e4dc07`

### Problem
Reported when testing the v0.4.47 build on macOS x86_64.

**Bug 1 — Dock icon never disappears:**
The app ran with the default `Regular` activation policy (always in the Dock). When `close_to_tray` hid the window, the macOS activation policy was never changed, so the Dock icon stayed visible even though only the tray icon should remain. Users expect a tray-only footprint — no Dock presence while minimized.

**Bug 2 — black window after restoring from tray:**
After `WindowEvent::hide()`, the WKWebView backing store is cleared. On the next `show()` the view painted blank and stayed black until some unrelated event triggered a redraw, leaving a black frame on screen.

### Fix (`src-tauri/src/lib.rs`)
Uses Tauri 2.10's own `AppHandle` macOS APIs following established Tauri v2 tray-app best practices (HiyokoBar article, Tauri 2.10 AppHandle docs).

- `show_main_window(app)` — calls `app.set_dock_visibility(true)` + `app.show()` (NSApplication.show()) before the window unminimize/show/set_focus. `app.show()` restores the NSApplication-layer state that `hide()` tears down, which forces the WKWebView backing store to refill (fixes black window).
- `hide_main_window(app)` — new helper combining `window.hide()` + `app.hide()` (NSApplication.hide()) + `set_dock_visibility(false)`. `app.hide()` makes the app vanish from Mission Control and the app switcher too, not just the Dock.
- All four show sites and the close-to-tray handler now use these helpers, eliminating duplicated inline show/hide logic.

Replaces manual `set_activation_policy(Regular/Accessory)` with Tauri's native `set_dock_visibility(true/false)` — the API recommended in Tauri's own docstring: *"Sets the dock visibility for the application"*.

### Cross-platform safety
`set_dock_visibility`, `app.show()`, and `app.hide()` are `#[cfg(target_os = "macos")]` in Tauri itself, so they compile out entirely on Windows/Linux. `show_main_window`/`hide_main_window` use only cross-platform `WebviewWindow` methods for window operations.

### Behavior on macOS now
| state | Dock icon | Mission Control |
|---|---|---|
| open | present | visible |
| close to tray | gone | hidden, tray icon remains |
| re-open from tray | returns | visible, window paints normally |

**Files:** `src-tauri/src/lib.rs` (+46 / -24)

---

Both fixes verified locally: `pnpm tsc --noEmit` clean, `cargo check` clean, full `pnpm tauri build` succeeds on macOS x86_64.