### PR TITLE
fix(config): persist generated defaults on first run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,14 @@ jobs:
           ANTIGRAVITY_CLIENT_ID: ${{ secrets.ANTIGRAVITY_CLIENT_ID }}
           ANTIGRAVITY_CLIENT_SECRET: ${{ secrets.ANTIGRAVITY_CLIENT_SECRET }}
 
+      - name: Rust tests
+        run: cargo test --lib
+        working-directory: src-tauri
+        env:
+          PROXYPAL_SKIP_SIDECAR: "1"
+          ANTIGRAVITY_CLIENT_ID: ${{ secrets.ANTIGRAVITY_CLIENT_ID }}
+          ANTIGRAVITY_CLIENT_SECRET: ${{ secrets.ANTIGRAVITY_CLIENT_SECRET }}
+
   build:
     name: Build (${{ matrix.platform }})
     needs: check

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -30,7 +30,12 @@ pub fn get_config(state: State<AppState>) -> AppConfig {
 }
 
 #[tauri::command]
-pub fn save_config(state: State<AppState>, config: AppConfig) -> Result<(), String> {
+pub fn save_config(state: State<AppState>, mut config: AppConfig) -> Result<(), String> {
+    // Keep the key the app signs with in step with what lands in the generated
+    // YAML; otherwise a key edited in Settings restarts the sidecar with a value
+    // the request headers never adopt (issue #89).
+    crate::config::reconcile_management_key(&mut config);
+
     // Debug: Log provider models before save
     eprintln!(
         "[ProxyPal Debug] Saving {} custom providers",

--- a/src-tauri/src/commands/proxy.rs
+++ b/src-tauri/src/commands/proxy.rs
@@ -998,6 +998,123 @@ mod tests {
         );
     }
 
+    /// End-to-end check against the real CLIProxyAPI binary: the generated YAML
+    /// must be accepted by the sidecar when requests are signed with the key
+    /// this process reports, and must keep working across a sidecar restart.
+    ///
+    /// Ignored by default because it needs the sidecar binary, which CI does not
+    /// download for the `check` job (`PROXYPAL_SKIP_SIDECAR=1`). Run locally:
+    ///   cargo test --lib generated_yaml_is_accepted -- --ignored --nocapture
+    #[test]
+    #[ignore]
+    fn generated_yaml_is_accepted_by_the_real_sidecar_across_restart() {
+        let sidecar = std::env::var("CLI_PROXY_API_BIN")
+            .unwrap_or_else(|_| "/usr/bin/cli-proxy-api".to_string());
+        assert!(
+            std::path::Path::new(&sidecar).exists(),
+            "sidecar not found at {sidecar}; set CLI_PROXY_API_BIN"
+        );
+
+        let root = std::env::temp_dir().join(format!("proxypal-e2e-{}", uuid::Uuid::new_v4()));
+        let auth_dir = root.join("auth");
+        std::fs::create_dir_all(&auth_dir).unwrap();
+
+        let key = crate::get_management_key();
+        let config = crate::config::AppConfig {
+            port: 18317,
+            management_key: key.clone(),
+            ..crate::config::AppConfig::default()
+        };
+        let yaml = build_proxy_config_yaml(&config, &root, &auth_dir, "").unwrap();
+        let yaml_path = root.join("proxy-config.yaml");
+        std::fs::write(&yaml_path, &yaml).unwrap();
+
+        let endpoints = [
+            "config.yaml",
+            "auth-files",
+            "gemini-api-key",
+            "claude-api-key",
+            "usage-queue?count=10",
+            "anthropic-auth-url?is_webui=true",
+            "config.yaml",
+            "auth-files",
+        ];
+
+        for round in ["first start", "after restart"] {
+            let mut child = std::process::Command::new(&sidecar)
+                .args(["-config", yaml_path.to_str().unwrap(), "-local-model"])
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .spawn()
+                .expect("failed to spawn sidecar");
+
+            let client = reqwest::blocking::Client::builder()
+                .no_proxy()
+                .timeout(std::time::Duration::from_secs(10))
+                .build()
+                .unwrap();
+            let base = "http://127.0.0.1:18317/v0/management";
+
+            // Wait for the listener.
+            let mut up = false;
+            for _ in 0..40 {
+                if client
+                    .get(format!("{base}/config.yaml"))
+                    .header("X-Management-Key", &key)
+                    .send()
+                    .is_ok()
+                {
+                    up = true;
+                    break;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(250));
+            }
+            assert!(up, "sidecar did not come up ({round})");
+
+            // Repeated calls: a mismatched key 401s and is banned after five tries,
+            // so anything other than an unbroken run of 200s fails here.
+            for ep in endpoints {
+                let status = client
+                    .get(format!("{base}/{ep}"))
+                    .header("X-Management-Key", &key)
+                    .send()
+                    .unwrap()
+                    .status();
+                assert_eq!(status.as_u16(), 200, "{ep} returned {status} ({round})");
+            }
+
+            let _ = child.kill();
+            let _ = child.wait();
+            std::thread::sleep(std::time::Duration::from_millis(500));
+        }
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn generated_yaml_secret_key_matches_the_management_request_key() {
+        // The defect this guards: the sidecar is configured with one key while
+        // requests are signed with another, so every management call 401s and the
+        // caller is banned after five tries.
+        let config = crate::config::AppConfig {
+            management_key: crate::config::management_key(),
+            ..crate::config::AppConfig::default()
+        };
+        let config_dir = std::path::PathBuf::from("/tmp/proxypal-test-key-match");
+        let auth_dir = std::path::PathBuf::from("/tmp/.cli-proxy-api-test");
+
+        let yaml = build_proxy_config_yaml(&config, &config_dir, &auth_dir, "").unwrap();
+
+        let header_key = crate::get_management_key();
+        assert!(
+            yaml.contains(&format!("secret-key: \"{}\"", header_key)),
+            "generated YAML secret-key must equal the X-Management-Key value.\n\
+             header key: {}\nyaml:\n{}",
+            header_key,
+            yaml
+        );
+    }
+
     #[test]
     fn build_proxy_config_yaml_sets_safe_defaults() {
         let config = crate::config::AppConfig::default();

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -286,7 +286,20 @@ fn migrate_config(config: &mut AppConfig) -> bool {
 
 fn load_config_from_path(path: &Path) -> AppConfig {
     if !path.exists() {
-        return AppConfig::default();
+        // Persist the generated defaults immediately. `management_key` is minted by
+        // `new_management_key()` on every `AppConfig::default()`, so without this every
+        // `load_config()` returns a different key: the value written into
+        // proxy-config.yaml's `remote-management.secret-key` could never match the
+        // `X-Management-Key` header, and CLIProxyAPI would ban the client after 5 tries.
+        let config = AppConfig::default();
+        if let Err(e) = save_config_to_path(path, &config) {
+            eprintln!(
+                "[ProxyPal] Failed to persist initial config '{}': {}",
+                path.display(),
+                e
+            );
+        }
+        return config;
     }
 
     let data = match std::fs::read_to_string(path) {
@@ -404,6 +417,28 @@ mod tests {
             loaded.routing_strategy,
             AppConfig::default().routing_strategy
         );
+
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn load_config_from_missing_file_persists_a_stable_management_key() {
+        let dir = test_dir("config-missing-persist");
+        let path = dir.join("config.json");
+
+        let first = load_config_from_path(&path);
+        assert!(
+            path.exists(),
+            "defaults must be persisted on first load so the generated key is stable"
+        );
+
+        let second = load_config_from_path(&path);
+        assert_eq!(
+            first.management_key, second.management_key,
+            "management key must not change between loads; the key written to \
+             proxy-config.yaml has to match the one sent in X-Management-Key"
+        );
+        assert_eq!(first.proxy_api_key, second.proxy_api_key);
 
         let _ = fs::remove_dir_all(dir);
     }

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::path::Path;
+use std::sync::RwLock;
 
 use uuid::Uuid;
 
@@ -145,6 +146,91 @@ fn new_management_key() -> String {
     format!("proxypal-{}", Uuid::new_v4())
 }
 
+/// The management key that predates per-install keys. Treated as "no key".
+const LEGACY_MANAGEMENT_KEY: &str = "proxypal-mgmt-key";
+
+/// Process-wide holder for the management key.
+///
+/// The key written into the generated proxy YAML and the key sent on every
+/// `X-Management-Key` header must be the same value, or CLIProxyAPI rejects the
+/// request with `401 invalid management key` and bans the caller after five
+/// tries. Every code path below can otherwise mint a fresh `Uuid` — a missing
+/// file, a missing field, a parse error, a read error — so both sides read from
+/// one store instead of re-deriving the key from disk per request.
+pub(crate) struct KeyStore(RwLock<Option<String>>);
+
+impl KeyStore {
+    pub(crate) const fn new() -> Self {
+        Self(RwLock::new(None))
+    }
+
+    /// Return the held key, adopting `candidate` only if nothing is held yet.
+    ///
+    /// First writer wins: concurrent first loads converge on one value, and a
+    /// key already in use is never swapped out from under a running sidecar.
+    pub(crate) fn resolve(&self, candidate: Option<&str>) -> String {
+        if let Some(existing) = self.read().as_ref() {
+            return existing.clone();
+        }
+        // Re-check under the write lock; another thread may have won the race.
+        let mut slot = self.0.write().unwrap_or_else(|p| p.into_inner());
+        if let Some(existing) = slot.as_ref() {
+            return existing.clone();
+        }
+        let key = match candidate {
+            Some(c) if !c.trim().is_empty() && c != LEGACY_MANAGEMENT_KEY => c.to_string(),
+            _ => new_management_key(),
+        };
+        *slot = Some(key.clone());
+        key
+    }
+
+    /// Replace the held key. Used when the user edits it in Settings.
+    pub(crate) fn set(&self, key: String) {
+        *self.0.write().unwrap_or_else(|p| p.into_inner()) = Some(key);
+    }
+
+    fn read(&self) -> std::sync::RwLockReadGuard<'_, Option<String>> {
+        self.0.read().unwrap_or_else(|p| p.into_inner())
+    }
+}
+
+static MANAGEMENT_KEY: KeyStore = KeyStore::new();
+
+/// The management key for this process — the single source used for both the
+/// generated proxy YAML and every management request header.
+///
+/// If nothing is held yet this seeds from the persisted config rather than
+/// minting on the spot, so a caller that runs before startup's `load_config()`
+/// cannot mint a throwaway key and have it overwrite the user's stored one.
+/// Costs at most one read for the life of the process.
+pub fn management_key() -> String {
+    if let Some(existing) = MANAGEMENT_KEY.read().as_ref() {
+        return existing.clone();
+    }
+    load_config().management_key
+}
+
+/// Reconcile a config coming from the UI with the key this process signs with.
+///
+/// A deliberate, non-empty change is adopted so the headers follow the value the
+/// sidecar is restarted with. A blank or legacy value is replaced with the key
+/// already in use, so a round-tripped config cannot silently rotate it.
+pub fn reconcile_management_key(config: &mut AppConfig) {
+    reconcile_management_key_with(config, &MANAGEMENT_KEY);
+}
+
+fn reconcile_management_key_with(config: &mut AppConfig, store: &KeyStore) {
+    let incoming = config.management_key.trim();
+    if incoming.is_empty() || incoming == LEGACY_MANAGEMENT_KEY {
+        config.management_key = store.resolve(None);
+    } else {
+        let incoming = incoming.to_string();
+        store.set(incoming.clone());
+        config.management_key = incoming;
+    }
+}
+
 impl Default for AppConfig {
     fn default() -> Self {
         Self {
@@ -245,12 +331,9 @@ pub fn load_config() -> AppConfig {
 fn migrate_config(config: &mut AppConfig) -> bool {
     let mut changed = false;
 
-    // Migrate legacy management key to a unique UUID-backed key
-    if config.management_key == "proxypal-mgmt-key" {
-        eprintln!("[ProxyPal] Migrating legacy management key to a unique key...");
-        config.management_key = new_management_key();
-        changed = true;
-    }
+    // Legacy management keys are handled in `KeyStore::resolve`, which treats
+    // LEGACY_MANAGEMENT_KEY as "no key" so a unique one is minted and persisted.
+    // Doing it there keeps one owner for the key across every load path.
 
     // Migrate deprecated single amp_openai_provider to providers array
     if let Some(old_provider) = config.amp_openai_provider.take() {
@@ -285,49 +368,89 @@ fn migrate_config(config: &mut AppConfig) -> bool {
 }
 
 fn load_config_from_path(path: &Path) -> AppConfig {
-    if !path.exists() {
-        // Persist the generated defaults immediately. `management_key` is minted by
-        // `new_management_key()` on every `AppConfig::default()`, so without this every
-        // `load_config()` returns a different key: the value written into
-        // proxy-config.yaml's `remote-management.secret-key` could never match the
-        // `X-Management-Key` header, and CLIProxyAPI would ban the client after 5 tries.
-        let config = AppConfig::default();
-        if let Err(e) = save_config_to_path(path, &config) {
-            eprintln!(
-                "[ProxyPal] Failed to persist initial config '{}': {}",
-                path.display(),
-                e
-            );
-        }
-        return config;
-    }
+    load_config_from_path_with(path, &MANAGEMENT_KEY)
+}
 
-    let data = match std::fs::read_to_string(path) {
-        Ok(data) => data,
-        Err(e) => {
-            eprintln!(
-                "[ProxyPal] Failed to read config file '{}': {}. Falling back to defaults.",
-                path.display(),
-                e
-            );
-            return AppConfig::default();
+/// Load config, guaranteeing the returned `management_key` is the one `store`
+/// holds for this process, and persisting it when the file can be rewritten
+/// safely.
+///
+/// `store` is a parameter so tests can exercise the fallbacks in isolation
+/// rather than sharing the process-wide key.
+fn load_config_from_path_with(path: &Path, store: &KeyStore) -> AppConfig {
+    let existed = path.exists();
+
+    let data = if existed {
+        match std::fs::read_to_string(path) {
+            Ok(data) => Some(data),
+            Err(e) => {
+                eprintln!(
+                    "[ProxyPal] Failed to read config file '{}': {}. Falling back to defaults.",
+                    path.display(),
+                    e
+                );
+                None
+            }
         }
+    } else {
+        None
     };
 
-    let mut config = match serde_json::from_str::<AppConfig>(&data) {
-        Ok(config) => config,
-        Err(e) => {
+    // Probe the raw JSON separately: `#[serde(default = "default_management_key")]`
+    // mints a fresh UUID for an absent field, which is indistinguishable from a
+    // real one once deserialized.
+    let stored_key = data.as_deref().and_then(|d| {
+        serde_json::from_str::<serde_json::Value>(d)
+            .ok()
+            .and_then(|v| {
+                v.get("managementKey")
+                    .and_then(|k| k.as_str())
+                    .map(str::to_string)
+            })
+    });
+
+    let mut parsed_cleanly = false;
+    let mut config = match data.as_deref().map(serde_json::from_str::<AppConfig>) {
+        Some(Ok(config)) => {
+            parsed_cleanly = true;
+            config
+        }
+        Some(Err(e)) => {
             eprintln!(
                 "[ProxyPal] Failed to parse config file '{}': {}. Falling back to defaults.",
                 path.display(),
                 e
             );
-            return AppConfig::default();
+            AppConfig::default()
         }
+        None => AppConfig::default(),
     };
 
-    if migrate_config(&mut config) {
-        let _ = save_config_to_path(path, &config);
+    let resolved = store.resolve(stored_key.as_deref());
+    let key_changed = config.management_key != resolved;
+    config.management_key = resolved;
+
+    let migrated = migrate_config(&mut config);
+
+    // Rewrite only when the file is absent or parsed cleanly. A malformed or
+    // unreadable file is left alone — it may still hold recoverable settings,
+    // and the key is stable for this process regardless.
+    let writable = !existed || parsed_cleanly;
+    if writable && (!existed || key_changed || migrated) {
+        if let Err(e) = save_config_to_path(path, &config) {
+            eprintln!(
+                "[ProxyPal] Failed to persist config '{}': {}. \
+                 The management key is stable for this session but will not survive a restart.",
+                path.display(),
+                e
+            );
+        }
+    } else if !writable {
+        eprintln!(
+            "[ProxyPal] Leaving unreadable config '{}' untouched. \
+             Using a session-local management key; fix or remove the file to persist one.",
+            path.display()
+        );
     }
 
     config
@@ -355,8 +478,10 @@ pub(crate) fn save_config_to_path(path: &Path, config: &AppConfig) -> Result<(),
     let data = serde_json::to_string_pretty(config)
         .map_err(|e| format!("Failed to serialize config: {}", e))?;
 
-    // Write to temporary file first, then rename for atomic write
-    let temp_path = path.with_extension("tmp");
+    // Write to temporary file first, then rename for atomic write.
+    // The temp name is unique per write so concurrent savers cannot land on the
+    // same scratch file and interleave each other's bytes.
+    let temp_path = path.with_extension(format!("tmp-{}", Uuid::new_v4()));
 
     // Try writing to temp file with retry for Windows file locking issues
     let mut last_error = String::new();
@@ -416,6 +541,224 @@ mod tests {
         assert_eq!(
             loaded.routing_strategy,
             AppConfig::default().routing_strategy
+        );
+
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn a_key_edited_in_settings_becomes_the_process_key() {
+        // Issue #89: the sidecar is restarted with the new key, so the headers
+        // must follow or every management call 401s afterwards.
+        let store = KeyStore::new();
+        store.set("proxypal-old".to_string());
+        let mut config = AppConfig {
+            management_key: "proxypal-user-chose-this".to_string(),
+            ..AppConfig::default()
+        };
+
+        reconcile_management_key_with(&mut config, &store);
+
+        assert_eq!(config.management_key, "proxypal-user-chose-this");
+        assert_eq!(store.resolve(None), "proxypal-user-chose-this");
+    }
+
+    #[test]
+    fn a_blank_key_from_the_ui_keeps_the_key_in_use() {
+        let store = KeyStore::new();
+        store.set("proxypal-in-use".to_string());
+        let mut config = AppConfig {
+            management_key: "   ".to_string(),
+            ..AppConfig::default()
+        };
+
+        reconcile_management_key_with(&mut config, &store);
+
+        assert_eq!(
+            config.management_key, "proxypal-in-use",
+            "a round-tripped config missing the key must not rotate it"
+        );
+    }
+
+    #[test]
+    fn existing_config_without_management_key_gets_one_persisted() {
+        let dir = test_dir("config-no-key");
+        let path = dir.join("config.json");
+        // A realistic upgrade path: an old config that predates `managementKey`.
+        fs::write(
+            &path,
+            r#"{"port":8317,"autoStart":true,"launchAtLogin":false,"locale":"fr"}"#,
+        )
+        .unwrap();
+        let store = KeyStore::new();
+
+        let first = load_config_from_path_with(&path, &store);
+        let second = load_config_from_path_with(&path, &store);
+
+        assert!(!first.management_key.is_empty());
+        assert_eq!(
+            first.management_key, second.management_key,
+            "a config lacking managementKey must have one written, not regenerated per load"
+        );
+        let on_disk: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(
+            on_disk.get("managementKey").and_then(|v| v.as_str()),
+            Some(first.management_key.as_str()),
+            "the key must be written back to disk"
+        );
+        assert_eq!(
+            on_disk.get("locale").and_then(|v| v.as_str()),
+            Some("fr"),
+            "unrelated settings must be preserved when backfilling the key"
+        );
+
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn malformed_config_still_yields_one_stable_key_and_keeps_the_file() {
+        let dir = test_dir("config-malformed");
+        let path = dir.join("config.json");
+        fs::write(&path, "{ not valid json").unwrap();
+        let store = KeyStore::new();
+
+        let first = load_config_from_path_with(&path, &store);
+        let second = load_config_from_path_with(&path, &store);
+
+        assert_eq!(
+            first.management_key, second.management_key,
+            "a malformed config must not produce a different key on every load"
+        );
+        assert_eq!(
+            fs::read_to_string(&path).unwrap(),
+            "{ not valid json",
+            "a malformed config must not be clobbered — it may be user-recoverable"
+        );
+
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn unreadable_config_still_yields_one_stable_key() {
+        let dir = test_dir("config-unreadable");
+        let path = dir.join("config.json");
+        fs::write(&path, "{}").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&path, fs::Permissions::from_mode(0o000)).unwrap();
+        }
+        let store = KeyStore::new();
+
+        let first = load_config_from_path_with(&path, &store);
+        let second = load_config_from_path_with(&path, &store);
+
+        assert_eq!(
+            first.management_key, second.management_key,
+            "an unreadable config must not produce a different key on every load"
+        );
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = fs::set_permissions(&path, fs::Permissions::from_mode(0o644));
+        }
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn persistence_failure_is_reported_not_swallowed() {
+        let dir = test_dir("config-readonly");
+        let sub = dir.join("locked");
+        fs::create_dir_all(&sub).unwrap();
+        let path = sub.join("config.json");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&sub, fs::Permissions::from_mode(0o500)).unwrap();
+        }
+
+        let result = save_config_to_path(&path, &AppConfig::default());
+
+        #[cfg(unix)]
+        assert!(
+            result.is_err(),
+            "an unwritable config directory must surface an error, not silently succeed"
+        );
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = fs::set_permissions(&sub, fs::Permissions::from_mode(0o700));
+        }
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn concurrent_first_loads_converge_on_a_single_key() {
+        let dir = test_dir("config-concurrent");
+        let path = dir.join("config.json");
+        let store = std::sync::Arc::new(KeyStore::new());
+
+        let keys: Vec<String> = std::thread::scope(|s| {
+            let handles: Vec<_> = (0..8)
+                .map(|_| {
+                    let p = path.clone();
+                    let st = std::sync::Arc::clone(&store);
+                    s.spawn(move || load_config_from_path_with(&p, &st).management_key)
+                })
+                .collect();
+            handles.into_iter().map(|h| h.join().unwrap()).collect()
+        });
+
+        let distinct: std::collections::HashSet<&String> = keys.iter().collect();
+        assert_eq!(
+            distinct.len(),
+            1,
+            "concurrent first loads must agree on one key, got {:?}",
+            distinct
+        );
+
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn management_key_survives_a_restart() {
+        let dir = test_dir("config-restart");
+        let path = dir.join("config.json");
+
+        // First "run" of the app.
+        let first = load_config_from_path_with(&path, &KeyStore::new()).management_key;
+        // A later run starts with an empty store, as a fresh process would.
+        let second = load_config_from_path_with(&path, &KeyStore::new()).management_key;
+
+        assert_eq!(
+            first, second,
+            "the persisted key must be adopted on restart, not regenerated"
+        );
+
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn a_key_already_in_the_store_is_not_replaced_by_disk() {
+        let store = KeyStore::new();
+        store.set("proxypal-in-use".to_string());
+
+        let dir = test_dir("config-store-wins");
+        let path = dir.join("config.json");
+        fs::write(
+            &path,
+            r#"{"port":8317,"autoStart":true,"launchAtLogin":false,"managementKey":"proxypal-on-disk"}"#,
+        )
+        .unwrap();
+
+        let loaded = load_config_from_path_with(&path, &store);
+
+        assert_eq!(
+            loaded.management_key, "proxypal-in-use",
+            "the running sidecar's key must win; swapping it mid-process would break every request"
         );
 
         let _ = fs::remove_dir_all(dir);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -23,9 +23,15 @@ use tauri::{
     Emitter, Manager,
 };
 
-/// Get management key from config (used for internal proxy API calls)
+/// Get management key for internal proxy API calls.
+///
+/// Reads the process-wide key rather than re-deriving it from `config.json` per
+/// request: every fallback in `load_config` can mint a fresh `Uuid`, so a disk
+/// read here could return a different key on each call and never match the
+/// `remote-management.secret-key` the sidecar was started with. This is also
+/// called from detached threads (the usage collector) that have no `AppState`.
 pub(crate) fn get_management_key() -> String {
-    load_config().management_key
+    crate::config::management_key()
 }
 
 // Windows-specific imports for hiding CMD windows


### PR DESCRIPTION
Fixes #235

## Problem

`AppConfig::default()` mints a new management key on every call:

```rust
// config.rs:144-146
fn new_management_key() -> String {
    format!("proxypal-{}", Uuid::new_v4())
}
```

When `config.json` does not exist yet, `load_config_from_path` returned that default **without writing it**, so every `load_config()` produced a different key.

The two sides that must agree don't:

| | source |
|---|---|
| `proxy-config.yaml` → `remote-management.secret-key` | `state.config`, loaded **once** at startup (`lib.rs:266` → `commands/proxy.rs:570` → `:107`/`:129`) |
| `X-Management-Key` header | `get_management_key()` → `load_config()`, a **fresh disk read per call** (`lib.rs:27-29`) |

With no `config.json` these can never match — and since `get_management_key()` is called per request at ~40 sites, **every request sends a different key**. CLIProxyAPI bans the client IP after 5 failed attempts, so the user sees a `403 Forbidden` toast on any provider configuration action, masking the underlying `401 invalid management key`.

Diagnostic signature, since `proxy_api_key` is a fixed constant (`config.rs:108-110`) while `management_key` is not:

```
GET /v1/models        -> 200    (fixed proxy_api_key)
GET /v0/management/*  -> 401    (regenerated management_key)  -> 403 after 5 tries
```

## Fix

Persist the generated defaults on first load, so the key is stable from the first read onwards:

```rust
 fn load_config_from_path(path: &Path) -> AppConfig {
     if !path.exists() {
-        return AppConfig::default();
+        let config = AppConfig::default();
+        if let Err(e) = save_config_to_path(path, &config) { /* log, continue */ }
+        return config;
     }
```

## Notes for review

**This mirrors an existing pattern in the same function.** `load_config_from_path` already writes during a load when `migrate_config` changes something (`config.rs:316-318`), so persisting-on-read is established here rather than novel.

**`AppConfig::default()` is deliberately left non-deterministic.** The existing test `default_management_key_is_unique_and_not_the_legacy_key` asserts two `default()` calls differ, so unique-per-install is clearly intended. This PR doesn't touch that — it makes the generated value *durable*, which is what a non-deterministic default requires to survive being read twice. That test still passes.

**Write failures are non-fatal.** If the config directory isn't writable the error is logged and the in-memory defaults are returned — identical to today's behaviour, so no new failure mode.

**Scope, against `AGENTS.md` "Ask first":** no `AppConfig` schema change (no fields added, removed or renamed), no new dependencies, and no change to the CLIProxyAPI lifecycle. The only behavioural change is that a first run now writes the `config.json` it would otherwise have kept only in memory.

## Alternatives considered

- **Have `get_management_key()` read from `AppState` instead of re-reading disk.** Arguably the better end state — it removes the two-sources-of-truth entirely — but it's a wider change (the helper is a free function used across four command modules) and not needed to fix the reported break. Happy to do this instead if you'd prefer.
- **Make the fallback key process-stable via `OnceLock`.** Fixes it within a process, but `config.json` still never gets written and the YAML secret would churn on every launch.

The chosen fix is the smallest one that addresses the actual cause: a generated default that is never persisted.

## Testing

```
cargo check                 pass    (with PROXYPAL_SKIP_SIDECAR=1, as in ci.yml)
cargo test --lib            52 passed, 0 failed
tsc --noEmit                pass
```

Added `load_config_from_missing_file_persists_a_stable_management_key`, which asserts two successive loads of a missing config return the same `management_key`. **Verified it fails without the fix:**

```
test config::tests::load_config_from_missing_file_persists_a_stable_management_key ... FAILED
panicked at src/config.rs:417:
  defaults must be persisted on first load so the generated key is stable
```

Two things I want to be upfront about rather than let a green check imply:

- **CI runs `cargo check`, not `cargo test`** (`ci.yml`), so this regression test will not run in CI. It was run locally; results above.
- **`oxlint`/`oxfmt` were not run locally** — local pnpm is 11.x and the repo's CI pins pnpm 9, whose ignored-builds behaviour differs. The diff is a single Rust file, so the JS/TS linters can't be affected by it, and CI will cover them regardless.

Verified end-to-end on the affected machine (Linux, ProxyPal 0.4.48, CLIProxyAPI 7.2.95): with a stable key present, `config.yaml`, `usage-queue`, `max-retry-interval`, `anthropic-auth-url`, `gemini-api-key`, `claude-api-key` and `auth-files` all return `200`, where previously every one returned `403`.
