### PR TITLE
docs: fix the broken star history chart in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,4 +109,4 @@ MIT
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=heyhuynhgiabuu/proxypal&type=Date)](https://star-history.com/#heyhuynhgiabuu/proxypal&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=heyhuynhgiabuu/proxypal&type=Date)](https://star-history.dera.page/#heyhuynhgiabuu/proxypal&Date)


### PR DESCRIPTION
The star history chart shown in the README has stopped rendering because the upstream service is affected by GitHub stargazer API restrictions. This change moves the chart to a working mirror so it displays correctly again.